### PR TITLE
fix(SecureNet): retry wolfSSL_connect across handshake round-trips

### DIFF
--- a/libs/network/SecureNet/src/SecureClient.cpp
+++ b/libs/network/SecureNet/src/SecureClient.cpp
@@ -68,7 +68,25 @@ int SecureClient::connect(const char* host, uint16_t port) {
   wolfSSL_SetIOWriteCtx(ssl, &_transport);
   wolfSSL_UseSNI(ssl, WOLFSSL_SNI_HOST_NAME, host, strlen(host));
 
-  if (wolfSSL_connect(ssl) != WOLFSSL_SUCCESS) { stop(); return 0; }
+  // The recv callback is non-blocking (returns WANT_READ when no bytes are
+  // buffered), so wolfSSL_connect must be retried across handshake round-trips
+  // rather than called once.
+  const uint32_t deadline = millis() + 15000;
+  int ret;
+  while ((ret = wolfSSL_connect(ssl)) != WOLFSSL_SUCCESS) {
+    const int err = wolfSSL_get_error(ssl, ret);
+    if (err != WOLFSSL_ERROR_WANT_READ && err != WOLFSSL_ERROR_WANT_WRITE) {
+      if (Serial) Serial.printf("[SecureClient] wolfSSL_connect failed: %d\n", err);
+      stop();
+      return 0;
+    }
+    if (static_cast<int32_t>(millis() - deadline) >= 0) {
+      if (Serial) Serial.printf("[SecureClient] handshake timeout\n");
+      stop();
+      return 0;
+    }
+    delay(5);
+  }
   _connected = true;
   return 1;
 }


### PR DESCRIPTION
## Problem

`SecureClient::connect()` calls `wolfSSL_connect()` exactly once and treats any non-`WOLFSSL_SUCCESS` return as a hard failure. But the I/O recv callback (`wcRecv`) is non-blocking — it returns `WOLFSSL_CBIO_ERR_WANT_READ` whenever the transport has no bytes buffered. On the very first `wolfSSL_connect()` call, the ServerHello hasn't arrived yet, so wolfSSL returns `WANT_READ` and `connect()` reports failure. As a result **every TLS 1.3 handshake fails** (observed against `github.com:443`).

## Fix

Loop `wolfSSL_connect()` while `wolfSSL_get_error()` is `WANT_READ`/`WANT_WRITE`, with a 15s timeout, and log the real wolfSSL error code on a genuine failure. This is the standard non-blocking-I/O handshake pattern.

## Testing

With this change, TLS 1.3 downloads from GitHub release assets complete reliably on ESP32-C3 (verified streaming multi-hundred-KB files; `minFreeEver` stays healthy, no handshake failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)