### PR TITLE
Add sdTotalBytes / sdUsedBytes to SDCardManager

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -28,6 +28,12 @@ class SDCardManager {
   SDCardManager();
   bool begin();
   bool ready() const;
+  // Returns the total card capacity in bytes. Cached at begin(); 0 if not mounted.
+  uint64_t sdTotalBytes() const;
+  // Returns used space in bytes, cached with a 20-second TTL (freeClusterCount
+  // scans the FAT and is too slow to call on every frame). 0 if not mounted or
+  // the cluster count cannot be determined.
+  uint64_t sdUsedBytes();
   std::vector<String> listFiles(const char* path = "/", int maxFiles = 200);
   // Read the entire file at `path` into a String. Returns empty string on failure.
   String readFile(const char* path);
@@ -72,6 +78,12 @@ class SDCardManager {
 
   bool initialized = false;
   PowerHook _powerHook = nullptr;
+
+  static constexpr uint32_t USED_BYTES_CACHE_TTL_MS = 20000;
+  uint64_t cachedTotalBytes = 0;
+  uint64_t cachedUsedBytes = 0;
+  uint32_t cachedUsedBytesAt = 0;
+  bool cachedUsedBytesValid = false;
 
   // All filesystem ops route through one FsVolume& so the backend is swappable.
   // SPI boards: `sd` (SdFs is-a FsVolume). SDMMC boards: a bare FsVolume mounted

--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -19,15 +19,21 @@ bool SDCardManager::begin() {
   if (!_dev->begin(BoardConfig::ACTIVE.sdmmc)) {
     if (Serial) Serial.printf("[%lu] [SD] SDMMC init failed\n", millis());
     initialized = false;
+    cachedTotalBytes = 0;
+    cachedUsedBytesValid = false;
     return false;
   }
   if (!_vol.begin(_dev)) {
     if (Serial) Serial.printf("[%lu] [SD] SDMMC volume mount failed\n", millis());
     initialized = false;
+    cachedTotalBytes = 0;
+    cachedUsedBytesValid = false;
     return false;
   }
   if (Serial) Serial.printf("[%lu] [SD] SDMMC card mounted\n", millis());
   initialized = true;
+  cachedTotalBytes = static_cast<uint64_t>(vol().clusterCount()) * vol().bytesPerCluster();
+  cachedUsedBytesValid = false;
   return initialized;
 }
 #else
@@ -70,9 +76,13 @@ bool SDCardManager::begin() {
                     millis(), sd.sdErrorCode(), sd.sdErrorData(), SD_CS, BoardConfig::ACTIVE.sd.sclk,
                     BoardConfig::ACTIVE.sd.miso, BoardConfig::ACTIVE.sd.mosi, (unsigned long)SPI_FQ);
     initialized = false;
+    cachedTotalBytes = 0;
+    cachedUsedBytesValid = false;
   } else {
     if (Serial) Serial.printf("[%lu] [SD] SD card detected\n", millis());
     initialized = true;
+    cachedTotalBytes = static_cast<uint64_t>(vol().clusterCount()) * vol().bytesPerCluster();
+    cachedUsedBytesValid = false;
   }
 
   return initialized;
@@ -283,6 +293,28 @@ bool SDCardManager::openFileForWrite(const char* moduleName, const std::string& 
 
 bool SDCardManager::openFileForWrite(const char* moduleName, const String& path, FsFile& file) {
   return openFileForWrite(moduleName, path.c_str(), file);
+}
+
+uint64_t SDCardManager::sdTotalBytes() const { return cachedTotalBytes; }
+
+uint64_t SDCardManager::sdUsedBytes() {
+  if (!initialized) return 0;
+  const uint32_t now = millis();
+  if (!cachedUsedBytesValid || (now - cachedUsedBytesAt) >= USED_BYTES_CACHE_TTL_MS) {
+    const int32_t freeClusters = vol().freeClusterCount();
+    const uint64_t clusterCount = vol().clusterCount();
+    if (freeClusters < 0) {
+      cachedUsedBytes = 0;
+    } else {
+      const uint64_t cappedFree = (static_cast<uint64_t>(freeClusters) > clusterCount)
+                                      ? clusterCount
+                                      : static_cast<uint64_t>(freeClusters);
+      cachedUsedBytes = (clusterCount - cappedFree) * vol().bytesPerCluster();
+    }
+    cachedUsedBytesValid = true;
+    cachedUsedBytesAt = now;
+  }
+  return cachedUsedBytes;
 }
 
 bool SDCardManager::removeDir(const char* path) {


### PR DESCRIPTION
Ports the SD card space query API from crosspoint-xdk. Total capacity is cached at begin() (cluster count × bytes per cluster); used space is cached with a 20-second TTL because freeClusterCount scans the FAT and is too slow to call on every frame. Both methods work for the SPI and native SDMMC (SDIO) backends through the existing FsVolume& vol() abstraction.