### PR TITLE
Add framebuffer release/reclaim APIs and fix grayscale cleanup restore

### DIFF
--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -92,6 +92,12 @@ class FreeInkDisplay {
   bool supportsStripGrayscale() const;
 #ifdef EINK_DISPLAY_SINGLE_BUFFER_MODE
   void cleanupGrayscaleBuffers(const uint8_t* bwBuffer);
+#else
+  // Restore controller RAM and frameBuffer to the BW baseline after grayscale.
+  // Uses frameBufferActive as the source (falls back to frameBuffer when the
+  // secondary buffer has been released). Call once per page-turn after
+  // displayGrayBuffer() to ensure the next BW draw targets a valid BW frame.
+  void cleanupGrayscaleWithPreviousBuffer();
 #endif
 
   void displayBuffer(RefreshMode mode = FAST_REFRESH, bool turnOffScreen = false);
@@ -116,6 +122,39 @@ class FreeInkDisplay {
 
   // Access to frame buffer
   uint8_t* getFrameBuffer() const { return frameBuffer; }
+
+  // Copy the just-displayed frame (frameBufferActive) back into the write buffer.
+  // displayBuffer() ends with swapBuffers(), so the write buffer would otherwise
+  // hold the frame from two refreshes ago. Call this before patching a few regions
+  // and re-displaying instead of fully re-rendering. No-op in single-buffer mode.
+  void syncWriteBufferFromActive() const;
+
+#if FREEINK_FB_PSRAM
+  // Release both framebuffers back to the heap. After this call no display
+  // operations may be performed until begin() is called again. Intended for
+  // transient sessions (e.g. a web UI) where the device reboots on exit and the
+  // ~100 KB of PSRAM is more valuable than rendering ability. Safe no-op if
+  // already released.
+  void releaseBuffers();
+
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  // Release only the secondary (previous-frame) buffer to free ~48-52 KB of
+  // PSRAM temporarily — e.g. during chapter compilation when no rendering
+  // is happening. BW display and fast differential refresh continue to work:
+  // the SSD1677 driver already re-seeds both BW and RED RAM when prev is null,
+  // so the differential baseline stays consistent without the host copy.
+  // Grayscale AA is unavailable until the buffer is restored with
+  // reallocSecondaryBuffer(). No-op if already released. Returns true if freed.
+  bool releaseSecondaryBuffer();
+
+  // Reallocate the secondary buffer after releaseSecondaryBuffer(). Initialises
+  // it to white (0xFF). Returns true on success; false if malloc fails.
+  bool reallocSecondaryBuffer();
+
+  // Returns true if the secondary buffer is currently allocated.
+  bool hasSecondaryBuffer() const;
+#endif  // !EINK_DISPLAY_SINGLE_BUFFER_MODE
+#endif  // FREEINK_FB_PSRAM
 
   // Save the current framebuffer to a PBM file (desktop/test builds only)
   void saveFrameBufferAsPBM(const char* filename);

--- a/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
+++ b/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
@@ -219,11 +219,64 @@ void FreeInkDisplay::setFramebuffer(const uint8_t* bwBuffer) const { memcpy(fram
 
 #ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
 void FreeInkDisplay::swapBuffers() {
+  // When the secondary buffer has been released, frameBufferActive is null.
+  // Swapping would set frameBuffer to null and corrupt every subsequent pixel
+  // write. The driver already handles prev==nullptr correctly (X3 ignores it;
+  // X4 re-seeds both BW and RED controller RAM after the refresh), so keeping
+  // frameBuffer on the same allocation is correct here.
+  if (!frameBufferActive) return;
   uint8_t* temp = frameBuffer;
   frameBuffer = frameBufferActive;
   frameBufferActive = temp;
 }
 #endif
+
+void FreeInkDisplay::syncWriteBufferFromActive() const {
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  if (frameBuffer && frameBufferActive) memcpy(frameBuffer, frameBufferActive, bufferSize);
+#endif
+}
+
+#if FREEINK_FB_PSRAM
+void FreeInkDisplay::releaseBuffers() {
+  free(frameBuffer0);
+  frameBuffer0 = nullptr;
+  frameBuffer = nullptr;
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  free(frameBuffer1);
+  frameBuffer1 = nullptr;
+  frameBufferActive = nullptr;
+#endif
+}
+
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+bool FreeInkDisplay::releaseSecondaryBuffer() {
+  if (!frameBufferActive) return false;
+  if (frameBufferActive == frameBuffer0) {
+    free(frameBuffer0);
+    frameBuffer0 = nullptr;
+  } else {
+    free(frameBuffer1);
+    frameBuffer1 = nullptr;
+  }
+  frameBufferActive = nullptr;
+  return true;
+}
+
+bool FreeInkDisplay::reallocSecondaryBuffer() {
+  if (frameBufferActive) return true;
+  uint8_t** slot = (frameBuffer0 == nullptr) ? &frameBuffer0 : &frameBuffer1;
+  *slot = static_cast<uint8_t*>(heap_caps_malloc(MAX_BUFFER_SIZE, MALLOC_CAP_SPIRAM));
+  if (!*slot) *slot = static_cast<uint8_t*>(malloc(MAX_BUFFER_SIZE));
+  if (!*slot) return false;
+  frameBufferActive = *slot;
+  memset(frameBufferActive, 0xFF, bufferSize);
+  return true;
+}
+
+bool FreeInkDisplay::hasSecondaryBuffer() const { return frameBufferActive != nullptr; }
+#endif  // !EINK_DISPLAY_SINGLE_BUFFER_MODE
+#endif  // FREEINK_FB_PSRAM
 
 // ============================================================================
 // Panel operations (delegated to the active driver)
@@ -293,6 +346,17 @@ bool FreeInkDisplay::supportsStripGrayscale() const { return _driver && _driver-
 #ifdef EINK_DISPLAY_SINGLE_BUFFER_MODE
 void FreeInkDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) {
   _driver->cleanupGrayscaleBuffers(_bus, bwBuffer);
+  // Restore frameBuffer so subsequent BW draws paint onto a valid BW baseline
+  // rather than the stale LSB/MSB grayscale plane data that was there before.
+  if (frameBuffer && bwBuffer && frameBuffer != bwBuffer)
+    memcpy(frameBuffer, bwBuffer, bufferSize);
+}
+#else
+void FreeInkDisplay::cleanupGrayscaleWithPreviousBuffer() {
+  const uint8_t* baseline = frameBufferActive ? frameBufferActive : frameBuffer;
+  _driver->cleanupGrayscaleBuffers(_bus, baseline);
+  if (frameBuffer && baseline && frameBuffer != baseline)
+    memcpy(frameBuffer, baseline, bufferSize);
 }
 #endif
 


### PR DESCRIPTION
## Summary

Ports framebuffer lifecycle management from the crosspoint-xdk reference implementation to freeink-sdk, eliminating the need for a third scratch buffer and enabling on-demand PSRAM reclaim without sacrificing display correctness.

**Buffer swap reuse** — no third copy buffer required
- After each `displayBuffer()` the swap hands the caller the buffer the controller just finished reading. The caller draws directly into it; `frameBufferActive` simultaneously holds the last-displayed frame as the differential baseline for the next refresh. Memory stays at two allocations, zero copies for the common path.
- `syncWriteBufferFromActive()` added as an opt-in shortcut: copies the just-displayed frame into the write buffer so callers can patch a few regions and re-display without a full redraw.

**On-demand secondary buffer release/reclaim** (`FREEINK_FB_PSRAM`, dual-buffer builds)
- `releaseSecondaryBuffer()` frees the ~48–52 KB prev-frame buffer when grayscale AA is not needed (e.g. during chapter compilation or asset loading). BW display and fast differential refresh continue uninterrupted: the SSD1677 driver already re-seeds both BW and RED controller RAM when `prev == nullptr`, so the differential baseline stays consistent without the host copy. X3 ignores `prev` entirely and is unaffected.
- `reallocSecondaryBuffer()` reclaims the buffer (initialised to white) when AA grayscale is needed again.
- `hasSecondaryBuffer()` lets callers query state without inspecting internals.
- `releaseBuffers()` drops both allocations entirely for sessions (e.g. a web UI) that reboot on exit and need every byte of PSRAM.

**`swapBuffers()` null guard** — correctness fix for released secondary buffer
- Without the guard, `displayBuffer()` after `releaseSecondaryBuffer()` would swap `frameBuffer` to `nullptr`, corrupting every subsequent pixel write. The guard keeps `frameBuffer` on its live allocation; the driver handles `prev == nullptr` correctly on both X3 and X4.

**Grayscale cleanup framebuffer restore** — parity with crosspoint-xdk
- `cleanupGrayscaleBuffers()` (single-buffer): after restoring controller RAM from `bwBuffer`, now also `memcpy`s `bwBuffer` → `frameBuffer`. Without this, `frameBuffer` would still hold stale LSB/MSB grayscale plane data and the next BW draw would corrupt on a stale baseline.
- `cleanupGrayscaleWithPreviousBuffer()` (dual-buffer): new convenience wrapper that picks the right source automatically (`frameBufferActive` when present, `frameBuffer` otherwise) and does the same driver call + framebuffer restore. Direct equivalent of `cleanupGrayscaleWithPreviousBuffer()` in crosspoint-xdk.

## Test plan

- [ ] Dual-buffer normal flow: display several pages; verify no ghosting and no third allocation appears in heap stats
- [ ] `syncWriteBufferFromActive()`: call after display, patch one region, redisplay; confirm only the patched region changes
- [ ] `releaseSecondaryBuffer()` → several BW FAST refreshes → `reallocSecondaryBuffer()` → AA grayscale page; confirm no corruption at any stage
- [ ] `releaseSecondaryBuffer()` → `displayBuffer(FAST_REFRESH)` → confirm `swapBuffers()` is a no-op and `frameBuffer` is non-null after the call
- [ ] `releaseBuffers()` → confirm `getFrameBuffer()` returns `nullptr` and no crash; reboot to recover
- [ ] `cleanupGrayscaleWithPreviousBuffer()`: display an AA grayscale page, call cleanup, then draw and display a BW page; confirm clean render with no grayscale ghosting
- [ ] X3 secondary-buffer release: release secondary, display several pages, confirm X3 driver behaviour unchanged (it ignores `prev` regardless)