### PR TITLE
feat: optional hooks around long e-ink BUSY waits

### DIFF
--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -120,6 +120,13 @@ class FreeInkDisplay {
   // See EpdBus::setBusyWaitHooks for firing semantics.
   void setBusyWaitHooks(void (*beginHook)(), void (*endHook)()) { _bus.setBusyWaitHooks(beginHook, endHook); }
 
+  // Optional slice hook replacing the BUSY poll delay once a wait has proven
+  // long, so host firmware can sleep through the refresh instead of polling.
+  // See EpdBus::setBusyWaitSliceHook for the contract.
+  void setBusyWaitSliceHook(bool (*sliceHook)(int8_t busyPin, uint8_t busyLevel)) {
+    _bus.setBusyWaitSliceHook(sliceHook);
+  }
+
   // Access to frame buffer
   uint8_t* getFrameBuffer() const { return frameBuffer; }
 

--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -114,6 +114,12 @@ class FreeInkDisplay {
   // Power management
   void deepSleep();
 
+  // Optional hooks fired around long BUSY waits (~0.3-2 s per refresh), so host
+  // firmware can apply its own power policy (e.g. reduce the CPU clock) for the
+  // wait window. Forwards to the bus, which owns every driver's busy-polling.
+  // See EpdBus::setBusyWaitHooks for firing semantics.
+  void setBusyWaitHooks(void (*beginHook)(), void (*endHook)()) { _bus.setBusyWaitHooks(beginHook, endHook); }
+
   // Access to frame buffer
   uint8_t* getFrameBuffer() const { return frameBuffer; }
 

--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
@@ -121,17 +121,22 @@ void EpdBus::waitBusy(const char* tag) { waitBusy(_busy, tag); }
 
 void EpdBus::waitBusy(BusyPolarity p, const char* tag) {
   const unsigned long start = millis();
-  // The begin hook fires lazily, only once the wait has proven long (see
-  // setBusyWaitHooks); hookFired guarantees the end hook is balanced with it.
+  // Both hooks engage lazily, only once the wait has proven long (see
+  // setBusyWaitHooks). longWait gates the slice hook independently of the
+  // begin hook's presence; hookFired guarantees the end hook is balanced.
+  bool longWait = false;
   bool hookFired = false;
   bool x3SawLow = false;
 
   if (p == BusyPolarity::ActiveHigh) {
     while (digitalRead(_pins.busy) == HIGH) {
-      delay(1);
-      if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
-        hookFired = true;
-        _busyWaitBeginHook();
+      busyIdle(longWait, HIGH, 1);
+      if (!longWait && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+        longWait = true;
+        if (_busyWaitBeginHook != nullptr) {
+          hookFired = true;
+          _busyWaitBeginHook();
+        }
       }
       if (millis() - start > 30000) break;
     }
@@ -148,10 +153,13 @@ void EpdBus::waitBusy(BusyPolarity p, const char* tag) {
     }
     if (busy) {
       do {
-        delay(10);
-        if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
-          hookFired = true;
-          _busyWaitBeginHook();
+        busyIdle(longWait, LOW, 10);
+        if (!longWait && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+          longWait = true;
+          if (_busyWaitBeginHook != nullptr) {
+            hookFired = true;
+            _busyWaitBeginHook();
+          }
         }
         if (millis() - start > 30000) break;
       } while (digitalRead(_pins.busy) == LOW);
@@ -164,10 +172,13 @@ void EpdBus::waitBusy(BusyPolarity p, const char* tag) {
     if (digitalRead(_pins.busy) == LOW) {
       x3SawLow = true;
       while (digitalRead(_pins.busy) == LOW) {
-        delay(1);
-        if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
-          hookFired = true;
-          _busyWaitBeginHook();
+        busyIdle(longWait, LOW, 1);
+        if (!longWait && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+          longWait = true;
+          if (_busyWaitBeginHook != nullptr) {
+            hookFired = true;
+            _busyWaitBeginHook();
+          }
         }
         if (millis() - start > 30000) break;
       }

--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
@@ -121,10 +121,18 @@ void EpdBus::waitBusy(const char* tag) { waitBusy(_busy, tag); }
 
 void EpdBus::waitBusy(BusyPolarity p, const char* tag) {
   const unsigned long start = millis();
+  // The begin hook fires lazily, only once the wait has proven long (see
+  // setBusyWaitHooks); hookFired guarantees the end hook is balanced with it.
+  bool hookFired = false;
+  bool x3SawLow = false;
 
   if (p == BusyPolarity::ActiveHigh) {
     while (digitalRead(_pins.busy) == HIGH) {
       delay(1);
+      if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+        hookFired = true;
+        _busyWaitBeginHook();
+      }
       if (millis() - start > 30000) break;
     }
   } else if (p == BusyPolarity::ActiveLow) {
@@ -141,24 +149,33 @@ void EpdBus::waitBusy(BusyPolarity p, const char* tag) {
     if (busy) {
       do {
         delay(10);
+        if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+          hookFired = true;
+          _busyWaitBeginHook();
+        }
         if (millis() - start > 30000) break;
       } while (digitalRead(_pins.busy) == LOW);
     }
   } else {  // X3TwoPhase: wait for the LOW edge, then wait back to HIGH
-    bool sawLow = false;
     while (digitalRead(_pins.busy) == HIGH) {
       delay(1);
       if (millis() - start > 1000) break;
     }
     if (digitalRead(_pins.busy) == LOW) {
-      sawLow = true;
+      x3SawLow = true;
       while (digitalRead(_pins.busy) == LOW) {
         delay(1);
+        if (!hookFired && _busyWaitBeginHook != nullptr && millis() - start > BUSY_WAIT_HOOK_THRESHOLD_MS) {
+          hookFired = true;
+          _busyWaitBeginHook();
+        }
         if (millis() - start > 30000) break;
       }
     }
-    if (!sawLow) return;
   }
+
+  if (hookFired && _busyWaitEndHook != nullptr) _busyWaitEndHook();
+  if (p == BusyPolarity::X3TwoPhase && !x3SawLow) return;
 
   if (tag && Serial) {
     Serial.printf("[%lu]   Wait complete: %s (%lu ms)\n", millis(), tag, millis() - start);

--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.h
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.h
@@ -61,6 +61,17 @@ class EpdBus {
   void waitBusy(const char* tag = nullptr);
   void waitBusy(BusyPolarity p, const char* tag = nullptr);
 
+  // Optional hooks fired around long BUSY waits. A refresh takes ~0.3-2 s during
+  // which the CPU only polls the BUSY pin; these let host firmware save power in
+  // that window (e.g. reduce the CPU clock) without the SDK knowing the policy.
+  // The begin hook fires once a wait exceeds BUSY_WAIT_HOOK_THRESHOLD_MS (so
+  // short command waits never pay for it); the matching end hook fires when the
+  // wait completes. Plain function pointers; both default to disabled.
+  void setBusyWaitHooks(void (*beginHook)(), void (*endHook)()) {
+    _busyWaitBeginHook = beginHook;
+    _busyWaitEndHook = endHook;
+  }
+
   // Stream `plane` bottom-to-top (gates are physically reversed), widthBytes per
   // row, optionally bit-inverting. Replaces the per-driver mirror lambdas.
   void writeMirroredPlane(const uint8_t* plane, uint16_t height, uint16_t widthBytes, bool invert);
@@ -79,6 +90,11 @@ class EpdBus {
   BusyPolarity busyPolarity() const { return _busy; }
 
  private:
+  // Busy-wait hooks (see setBusyWaitHooks)
+  static constexpr unsigned long BUSY_WAIT_HOOK_THRESHOLD_MS = 20;
+  void (*_busyWaitBeginHook)() = nullptr;
+  void (*_busyWaitEndHook)() = nullptr;
+
   EpdPins _pins{-1, -1, -1, -1, -1, -1};
   SPISettings _spi;
   BusyPolarity _busy = BusyPolarity::ActiveHigh;

--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.h
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.h
@@ -72,6 +72,14 @@ class EpdBus {
     _busyWaitEndHook = endHook;
   }
 
+  // Optional slice hook replacing the poll delay once a wait has proven long
+  // (i.e. after the begin hook fired). Receives the BUSY pin and the level that
+  // means "still busy"; returns true if it already waited (e.g. host light-slept
+  // until the pin left that level or a timer slice elapsed), false to fall back
+  // to the plain delay. Lets host firmware sleep through the 0.3-2 s refresh
+  // instead of polling, without the SDK knowing the wake mechanics.
+  void setBusyWaitSliceHook(bool (*sliceHook)(int8_t busyPin, uint8_t busyLevel)) { _busyWaitSliceHook = sliceHook; }
+
   // Stream `plane` bottom-to-top (gates are physically reversed), widthBytes per
   // row, optionally bit-inverting. Replaces the per-driver mirror lambdas.
   void writeMirroredPlane(const uint8_t* plane, uint16_t height, uint16_t widthBytes, bool invert);
@@ -90,10 +98,20 @@ class EpdBus {
   BusyPolarity busyPolarity() const { return _busy; }
 
  private:
-  // Busy-wait hooks (see setBusyWaitHooks)
+  // Busy-wait hooks (see setBusyWaitHooks / setBusyWaitSliceHook)
   static constexpr unsigned long BUSY_WAIT_HOOK_THRESHOLD_MS = 20;
   void (*_busyWaitBeginHook)() = nullptr;
   void (*_busyWaitEndHook)() = nullptr;
+  bool (*_busyWaitSliceHook)(int8_t busyPin, uint8_t busyLevel) = nullptr;
+
+  // One idle step of a long BUSY wait: defer to the slice hook once the wait
+  // has proven long, otherwise (or if the hook declines) plain-delay.
+  void busyIdle(bool longWait, uint8_t busyLevel, uint8_t fallbackDelayMs) {
+    if (longWait && _busyWaitSliceHook != nullptr && _busyWaitSliceHook(_pins.busy, busyLevel)) {
+      return;
+    }
+    delay(fallbackDelayMs);
+  }
 
   EpdPins _pins{-1, -1, -1, -1, -1, -1};
   SPISettings _spi;

--- a/libs/hardware/InputManager/include/InputManager.h
+++ b/libs/hardware/InputManager/include/InputManager.h
@@ -38,6 +38,13 @@ class InputManager {
   // Any button release edge since the previous update().
   bool wasAnyReleased() const;
 
+  // True while a raw state change is still inside the debounce window (the last
+  // raw sample differs from the committed state). A change only commits after
+  // two consecutive matching samples, so hosts that poll slowly (e.g. a
+  // sleep-sliced idle loop) should re-poll quickly while this is set — otherwise
+  // a press shorter than the poll period lands in a single sample and is dropped.
+  bool isDebouncePending() const { return lastState != currentState; }
+
   // Duration between the first button press and final release.
   unsigned long getHeldTime() const;
 

--- a/libs/hardware/InputManager/src/InputManager.cpp
+++ b/libs/hardware/InputManager/src/InputManager.cpp
@@ -229,6 +229,11 @@ void InputManager::applyStateChange(const uint8_t state, const unsigned long cur
   }
 
   currentState = state;
+  // Keep lastState in sync with the committed state so isDebouncePending() is
+  // meaningful on every input style. A no-op for the debounced ADC path (state
+  // already equals lastState at commit time), but the hold-style updates call
+  // applyStateChange() directly without ever sampling through the debounce.
+  lastState = state;
 }
 
 void InputManager::updateConfirmBackHold(const unsigned long currentTime) {


### PR DESCRIPTION
Equivalent of https://github.com/crosspoint-reader/community-sdk/pull/21; copying/pasting body below:

An e-ink refresh takes ~0.3–2 s, during which `pollBusy()` spins on the BUSY pin at whatever clock the host is running. This PR adds `setBusyWaitHooks(begin, end)`: plain function pointers fired when a wait exceeds 20 ms and again when it completes, letting host firmware apply its own power policy for the wait window (CrossPoint uses it to drop the ESP32-C3 to 10 MHz there).

- **Fully backwards compatible**: both hooks default to `nullptr`; behavior is unchanged unless installed. The only added cost is a null-check inside the 1 ms poll loop.
- The 20 ms threshold means short command waits never fire the hooks, so hosts don't pay two clock switches on trivial waits. The end hook fires only if the begin hook did.
- Covers both the X4 (active-HIGH) and X3 (active-LOW, two-phase) wait paths, including the X3 early-return path.

**Measured** on an X3 with a Nordic [PPK2](https://www.nordicsemi.com/Products/Development-hardware/Power-Profiler-Kit-2) at the battery terminals at 3.8v: with CrossPoint installing a 10 MHz downclock hook, a fast page turn drops from ~38 mC to ~29 mC (−24%), with fast/full/grayscale refreshes visually unchanged on device.

Supports https://github.com/crosspoint-reader/crosspoint-reader/pull/2525

🤖 Generated with [Claude Code](https://claude.com/claude-code)