### PR TITLE
chore: add function to borrow/return secondary framebuffer without freeing it

### DIFF
--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -300,6 +300,23 @@ class FreeInkDisplay {
 
   // Returns true if the secondary buffer is currently allocated.
   bool hasSecondaryBuffer() const;
+
+  // Lend the secondary buffer's memory to the host WITHOUT freeing it: the
+  // display drops to single-buffer mode exactly like releaseSecondaryBuffer()
+  // (same fast-diff/refresh semantics apply), but the block stays owned here
+  // and is handed to the caller for scratch use (e.g. a section-build arena).
+  // Unlike release/realloc, the memory never enters the heap, so nothing can
+  // allocate inside it and returnSecondaryBuffer() CANNOT fail — the
+  // realloc-failure / fragmented-hole class of bugs is impossible by
+  // construction. Returns nullptr if there is no secondary buffer or it is
+  // already lent. *size receives the block size.
+  uint8_t* borrowSecondaryBuffer(size_t* size);
+
+  // Take the lent block back and restore dual-buffer mode. Seeds the buffer
+  // from the live framebuffer and arms the one-shot RED-baseline handling,
+  // identical to reallocSecondaryBuffer() (the build clobbered the contents).
+  // Returns false only if nothing was lent.
+  bool returnSecondaryBuffer();
 #endif  // !EINK_DISPLAY_SINGLE_BUFFER_MODE
 
   // Save the current framebuffer to a PBM file (desktop/test builds only)
@@ -339,6 +356,10 @@ class FreeInkDisplay {
   uint8_t* _asyncShadow = nullptr;
   bool _shadowValid = false;
   bool _buildLent = false;  // framebuffer storage lent to a build (see lendBuildStorage)
+  // Secondary buffer lent to the host (see borrowSecondaryBuffer): the block
+  // this points at is still owned by frameBuffer0/1; frameBufferActive is null
+  // while lent so all released-mode display semantics apply unchanged.
+  uint8_t* _secondaryLent = nullptr;
 
 #ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
   // One-shot, armed by reallocSecondaryBuffer(): the controller's RED RAM still

--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -356,12 +356,12 @@ class FreeInkDisplay {
   uint8_t* _asyncShadow = nullptr;
   bool _shadowValid = false;
   bool _buildLent = false;  // framebuffer storage lent to a build (see lendBuildStorage)
+
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
   // Secondary buffer lent to the host (see borrowSecondaryBuffer): the block
   // this points at is still owned by frameBuffer0/1; frameBufferActive is null
   // while lent so all released-mode display semantics apply unchanged.
   uint8_t* _secondaryLent = nullptr;
-
-#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
   // One-shot, armed by reallocSecondaryBuffer(): the controller's RED RAM still
   // holds the on-screen frame (host allocation never touches controller RAM),
   // while the fresh secondary may not — the host may have scribbled or cleared

--- a/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
+++ b/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
@@ -257,6 +257,11 @@ uint8_t* FreeInkDisplay::allocFrameBufferStorage() const {
 }
 
 void FreeInkDisplay::releaseBuffers() {
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  // The secondary block is in the host's hands — freeing it here would be a
+  // use-after-free and would orphan _secondaryLent. returnSecondaryBuffer() first.
+  if (_secondaryLent) return;
+#endif
   syncPendingAsync();  // a refresh in flight was fed from these buffers
   free(frameBuffer0);
   frameBuffer0 = nullptr;
@@ -274,6 +279,11 @@ void FreeInkDisplay::releaseBuffers() {
 }
 
 bool FreeInkDisplay::reallocBuffers() {
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  // While lent, frameBuffer0/1 still hold the block, so the slot checks below
+  // would reattach it as frameBufferActive and memset the borrower's scratch.
+  if (_secondaryLent) return false;
+#endif
   if (!frameBuffer0) frameBuffer0 = allocFrameBufferStorage();
   if (!frameBuffer0) return false;
   frameBuffer = frameBuffer0;
@@ -374,6 +384,11 @@ bool FreeInkDisplay::hasSecondaryBuffer() const { return frameBufferActive != nu
 
 uint8_t* FreeInkDisplay::borrowSecondaryBuffer(size_t* size) {
   if (!frameBufferActive || _secondaryLent) return nullptr;
+  // A deferred refresh is still reading these bytes (the last displayStart +
+  // swap parked the displayed frame here; X3's post-waveform DTM1 sync reads
+  // it in displayFinish). Drain before the host scribbles — same reason
+  // lendBuildStorage() syncs before lending the primary.
+  syncPendingAsync();
   _secondaryLent = frameBufferActive;
   frameBufferActive = nullptr;  // single-buffer mode, same as releaseSecondaryBuffer()
   if (size) *size = bufferSize;

--- a/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
+++ b/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
@@ -328,6 +328,7 @@ bool FreeInkDisplay::releaseSecondaryBuffer() {
 
 bool FreeInkDisplay::reallocSecondaryBuffer() {
   if (frameBufferActive) return true;
+  if (_secondaryLent) return false;  // lent, not freed: returnSecondaryBuffer() is the only way back
   uint8_t** slot = (frameBuffer0 == nullptr) ? &frameBuffer0 : &frameBuffer1;
   *slot = allocFrameBufferStorage();
   if (!*slot) return false;
@@ -370,6 +371,30 @@ const uint8_t* FreeInkDisplay::consumePrevFrameFor(RefreshMode effectiveMode) {
 }
 
 bool FreeInkDisplay::hasSecondaryBuffer() const { return frameBufferActive != nullptr; }
+
+uint8_t* FreeInkDisplay::borrowSecondaryBuffer(size_t* size) {
+  if (!frameBufferActive || _secondaryLent) return nullptr;
+  _secondaryLent = frameBufferActive;
+  frameBufferActive = nullptr;  // single-buffer mode, same as releaseSecondaryBuffer()
+  if (size) *size = bufferSize;
+  return _secondaryLent;
+}
+
+bool FreeInkDisplay::returnSecondaryBuffer() {
+  if (!_secondaryLent) return false;
+  frameBufferActive = _secondaryLent;
+  _secondaryLent = nullptr;
+  // Identical post-restore handling to reallocSecondaryBuffer(): the scratch
+  // user clobbered the contents, so seed from the live framebuffer and arm the
+  // one-shot so the next FAST diffs against the controller's retained RED.
+  if (frameBuffer) {
+    memcpy(frameBufferActive, frameBuffer, bufferSize);
+  } else {
+    memset(frameBufferActive, 0xFF, bufferSize);
+  }
+  _redBaselineAuthoritative = true;
+  return true;
+}
 #endif  // !EINK_DISPLAY_SINGLE_BUFFER_MODE
 
 // ============================================================================


### PR DESCRIPTION
borrowSecondaryBuffer() lends the secondary buffer's block to the host and drops to single-buffer mode exactly like releaseSecondaryBuffer(), but the memory stays owned here rather than entering the heap — so nothing can allocate inside it and returnSecondaryBuffer() cannot fail on a fragmented hole. The return seeds the buffer from the live framebuffer and re-arms the one-shot RED baseline, identical to reallocSecondaryBuffer(). Mirrors the existing borrowBuildStorage/returnBuildStorage pattern for the primary buffer; reallocSecondaryBuffer() gains a guard so a lent block is only recoverable via returnSecondaryBuffer().