### PR TITLE
fix: route Sticky serial through UART0

### DIFF
--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -239,7 +239,22 @@
 #endif
 #endif
 
+// Bidirectional serial transport exposed by the board's physical USB-C port.
+// Most boards route it through Arduino's selected Serial implementation, while
+// Sticky's on-board WCH bridge is wired to UART0 instead of native USB CDC.
+#if FREEINK_DEVICE_STICKY
+#define FREEINK_SERIAL_HAS_TX_TIMEOUT 0
+#else
+#define FREEINK_SERIAL_HAS_TX_TIMEOUT (ARDUINO_USB_CDC_ON_BOOT)
+#endif
+
 namespace BoardConfig {
+
+#if FREEINK_DEVICE_STICKY
+inline HardwareSerial& serialTransport() { return Serial0; }
+#else
+inline auto& serialTransport() { return Serial; }
+#endif
 
 // Physical device family. X3 and X4 are sibling devices on the same ESP32-C3
 // board (identical pinout, different panel/size): both profiles compile into the


### PR DESCRIPTION
## Summary

- Add `BoardConfig::serialTransport()` as the board-aware bidirectional serial interface.
- Route Sticky through `Serial0` because its USB-C WCH bridge is wired to UART0.
- Keep existing devices on Arduino’s selected `Serial` implementation.
- Expose `FREEINK_SERIAL_HAS_TX_TIMEOUT` so consumers only use USB CDC-specific APIs when supported.

## Context

Sticky’s USB-C port enumerates through a WCH USB-to-UART bridge. Consumers using native USB CDC could open the device successfully but would never receive protocol responses, resulting in serial read timeouts.

Keeping this selection in `BoardConfig` prevents applications from needing Sticky-specific transport checks.

## Validation

- `pio run -e sticky`
- `pio run -e default`
- `git diff --check`

Both firmware targets build successfully. A flashed-device USB transfer test remains pending.

## Risk

Low. Existing boards continue using the same `Serial` implementation. The change adds no heap allocations or persistent RAM usage.