### PR TITLE
feat: add abortable secure connection deadlines

### DIFF
--- a/libs/network/SecureNet/include/SecureClient.h
+++ b/libs/network/SecureNet/include/SecureClient.h
@@ -22,10 +22,14 @@
 #include <Client.h>
 #include <WiFiClient.h>
 
+#include <functional>
+
 namespace freeink {
 
 class SecureClient : public Client {
  public:
+  using AbortCallback = std::function<bool()>;
+
   SecureClient() = default;
   ~SecureClient() override;
 
@@ -36,6 +40,11 @@ class SecureClient : public Client {
   // Connect and perform a TLS 1.3 handshake to host:port (uses the SNI host).
   int connect(IPAddress ip, uint16_t port) override;
   int connect(const char* host, uint16_t port) override;
+  // Connect with one timeout shared by TCP setup, TLS negotiation, and the
+  // TLS 1.2 fallback. The optional callback can abort between handshake
+  // iterations. Existing connect() callers retain their current behavior.
+  int connectWithTimeout(const char* host, uint16_t port, uint32_t timeoutMs,
+                         const AbortCallback& shouldAbort = nullptr);
 
   size_t write(uint8_t b) override;
   size_t write(const uint8_t* buf, size_t size) override;
@@ -52,7 +61,8 @@ class SecureClient : public Client {
   static bool tls13Available();
 
  private:
-  int connectWithMethod(const char* host, uint16_t port, void* method, const char* label);
+  int connectWithMethod(const char* host, uint16_t port, void* method, const char* label, uint32_t deadline,
+                        const AbortCallback& shouldAbort);
 
   WiFiClient _transport;
   const char* _rootCA = nullptr;

--- a/libs/network/SecureNet/include/SecureHttpClient.h
+++ b/libs/network/SecureNet/include/SecureHttpClient.h
@@ -209,7 +209,7 @@ class SecureHttpClient {
     for (int attempt = 0; attempt < 2; ++attempt) {
       const bool reusing = connectionMatches();
       if (isAborted(shouldAbort)) return -1;
-      if (!ensureConnected()) return -1;
+      if (!ensureConnected(shouldAbort)) return -1;
 
       if (!writeRequest(method, payload, payloadLen)) {
         closeConnection();
@@ -251,8 +251,10 @@ class SecureHttpClient {
         } else if (name == "connection") {
           std::string v = value;
           std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
-          if (v.find("close") != std::string::npos) keepAlive = false;
-          else if (v.find("keep-alive") != std::string::npos) keepAlive = true;
+          if (v.find("close") != std::string::npos)
+            keepAlive = false;
+          else if (v.find("keep-alive") != std::string::npos)
+            keepAlive = true;
         }
       }
       if (_aborted) {
@@ -372,9 +374,7 @@ class SecureHttpClient {
     return !host.empty() && (scheme == "http" || scheme == "https");
   }
 
-  std::string hostHeader() const {
-    return hostHeaderFor(_scheme, _host, _port);
-  }
+  std::string hostHeader() const { return hostHeaderFor(_scheme, _host, _port); }
 
   static std::string hostHeaderFor(const std::string& scheme, const std::string& host, uint16_t port) {
     const uint16_t defaultPort = scheme == "https" ? 443 : 80;
@@ -391,24 +391,34 @@ class SecureHttpClient {
   }
 
   // Reuse the kept-alive connection when it matches, else (re)connect.
-  bool ensureConnected() {
+  bool ensureConnected(const AbortCallback& shouldAbort = nullptr) {
     if (connectionMatches()) return true;
     closeConnection();
+    if (isAborted(shouldAbort)) return false;
     if (_scheme == "https") {
       if (_insecure) {
         _secure.setInsecure();
       } else if (_rootCA) {
         _secure.setCACert(_rootCA);
       }
-      _secure.setTimeout(_timeoutMs / 1000);
-      if (!_secure.connect(_host.c_str(), _port)) return false;
+      const AbortCallback trackedAbort = [this, &shouldAbort]() { return isAborted(shouldAbort); };
+      if (!_secure.connectWithTimeout(_host.c_str(), _port, _timeoutMs, trackedAbort)) {
+        isAborted(shouldAbort);
+        return false;
+      }
       _conn = &_secure;
       _connHttps = true;
     } else {
-      _plain.setTimeout(_timeoutMs / 1000);
-      if (!_plain.connect(_host.c_str(), _port)) return false;
+      if (!_plain.connect(_host.c_str(), _port, static_cast<int32_t>(_timeoutMs))) {
+        isAborted(shouldAbort);
+        return false;
+      }
       _conn = &_plain;
       _connHttps = false;
+    }
+    if (isAborted(shouldAbort)) {
+      closeConnection();
+      return false;
     }
     _connHost = _host;
     _connPort = _port;

--- a/libs/network/SecureNet/src/SecureClient.cpp
+++ b/libs/network/SecureNet/src/SecureClient.cpp
@@ -7,6 +7,9 @@
 #include <wolfssl/ssl.h>
 #endif
 
+#include <algorithm>
+#include <limits>
+
 namespace freeink {
 
 bool SecureClient::tls13Available() {
@@ -53,9 +56,15 @@ bool isWantIo(const int err) {
   // an out-of-memory handshake spin until the deadline instead of failing fast.
   return err == WOLFSSL_ERROR_WANT_READ || err == WOLFSSL_ERROR_WANT_WRITE;
 }
+
+uint32_t remainingTimeMs(const uint32_t deadline) {
+  const int32_t remaining = static_cast<int32_t>(deadline - millis());
+  return remaining > 0 ? static_cast<uint32_t>(remaining) : 0;
+}
 }  // namespace
 
-int SecureClient::connectWithMethod(const char* host, uint16_t port, void* method, const char* label) {
+int SecureClient::connectWithMethod(const char* host, uint16_t port, void* method, const char* label,
+                                    const uint32_t deadline, const AbortCallback& shouldAbort) {
 #if defined(FREEINK_WOLFSSL_DEBUG)
   // Routes wolfSSL's internal trace through wolfSSL_Arduino_Serial_Print (the
   // application provides that hook). Shows exactly where a handshake stalls.
@@ -67,14 +76,23 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
 #endif
   const uint32_t started = millis();
   stop();
-  if (!_transport.connect(host, port)) {
+  if ((shouldAbort && shouldAbort()) || remainingTimeMs(deadline) == 0) return 0;
+
+  const uint32_t tcpTimeout =
+      std::min(remainingTimeMs(deadline), static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
+  if (!_transport.connect(host, port, static_cast<int32_t>(tcpTimeout))) {
     if (Serial) Serial.printf("[SecureClient] TCP connect failed (%s): %s:%u\n", label, host, port);
+    return 0;
+  }
+  if ((shouldAbort && shouldAbort()) || remainingTimeMs(deadline) == 0) {
+    _transport.stop();
     return 0;
   }
 
   auto* ctx = wolfSSL_CTX_new(static_cast<WOLFSSL_METHOD*>(method));
   if (!ctx) {
-    if (Serial) Serial.printf("[SecureClient] CTX alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
+    if (Serial)
+      Serial.printf("[SecureClient] CTX alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
     _transport.stop();
     return 0;
   }
@@ -83,15 +101,16 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   if (_insecure) {
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, nullptr);
   } else if (_rootCA) {
-    wolfSSL_CTX_load_verify_buffer(ctx, reinterpret_cast<const unsigned char*>(_rootCA),
-                                   strlen(_rootCA), WOLFSSL_FILETYPE_PEM);
+    wolfSSL_CTX_load_verify_buffer(ctx, reinterpret_cast<const unsigned char*>(_rootCA), strlen(_rootCA),
+                                   WOLFSSL_FILETYPE_PEM);
   }
   wolfSSL_SetIORecv(ctx, wcRecv);
   wolfSSL_SetIOSend(ctx, wcSend);
 
   auto* ssl = wolfSSL_new(ctx);
   if (!ssl) {
-    if (Serial) Serial.printf("[SecureClient] SSL alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
+    if (Serial)
+      Serial.printf("[SecureClient] SSL alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
     stop();
     return 0;
   }
@@ -113,7 +132,6 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   // The recv callback is non-blocking (returns WANT_READ when no bytes are
   // buffered), so wolfSSL_connect must be retried across handshake round-trips
   // rather than called once.
-  const uint32_t deadline = millis() + 15000;
   int ret;
   while ((ret = wolfSSL_connect(ssl)) != WOLFSSL_SUCCESS) {
     const int err = wolfSSL_get_error(ssl, ret);
@@ -122,7 +140,7 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
       stop();
       return 0;
     }
-    if (static_cast<int32_t>(millis() - deadline) >= 0) {
+    if ((shouldAbort && shouldAbort()) || remainingTimeMs(deadline) == 0) {
       if (Serial) {
         Serial.printf("[SecureClient] handshake timeout (%s): last err %d, transport %s, free heap %u\n", label, err,
                       _transport.connected() ? "up" : "down", (unsigned)ESP.getFreeHeap());
@@ -145,13 +163,24 @@ int SecureClient::connect(const char* host, uint16_t port) {
   // self-hosted / Let's Encrypt nginx often tops out at TLS 1.2, and a 1.3-only
   // client fails those handshakes outright. v23 still selects 1.3 when the peer
   // offers it (WOLFSSL_TLS13 is enabled) and falls back to 1.2 otherwise.
-  if (connectWithMethod(host, port, wolfSSLv23_client_method(), "auto")) return 1;
+  if (connectWithMethod(host, port, wolfSSLv23_client_method(), "auto", millis() + 15000, nullptr)) return 1;
 
   // Some TLS 1.2-only servers are intolerant of a TLS 1.3-capable ClientHello
   // and abort with a fatal handshake_failure alert. Retry with an explicit
   // TLS 1.2 ClientHello before giving up.
   if (Serial) Serial.println("[SecureClient] retrying with TLS 1.2-only handshake");
-  return connectWithMethod(host, port, wolfTLSv1_2_client_method(), "tls1.2");
+  return connectWithMethod(host, port, wolfTLSv1_2_client_method(), "tls1.2", millis() + 15000, nullptr);
+}
+
+int SecureClient::connectWithTimeout(const char* host, const uint16_t port, const uint32_t timeoutMs,
+                                     const AbortCallback& shouldAbort) {
+  if (timeoutMs == 0 || (shouldAbort && shouldAbort())) return 0;
+  const uint32_t deadline = millis() + timeoutMs;
+  if (connectWithMethod(host, port, wolfSSLv23_client_method(), "auto", deadline, shouldAbort)) return 1;
+  if (remainingTimeMs(deadline) == 0 || (shouldAbort && shouldAbort())) return 0;
+
+  if (Serial) Serial.println("[SecureClient] retrying with TLS 1.2-only handshake");
+  return connectWithMethod(host, port, wolfTLSv1_2_client_method(), "tls1.2", deadline, shouldAbort);
 }
 
 int SecureClient::connect(IPAddress ip, uint16_t port) {
@@ -188,8 +217,14 @@ int SecureClient::available() {
 }
 
 void SecureClient::stop() {
-  if (_ssl) { wolfSSL_free(static_cast<WOLFSSL*>(_ssl)); _ssl = nullptr; }
-  if (_ctx) { wolfSSL_CTX_free(static_cast<WOLFSSL_CTX*>(_ctx)); _ctx = nullptr; }
+  if (_ssl) {
+    wolfSSL_free(static_cast<WOLFSSL*>(_ssl));
+    _ssl = nullptr;
+  }
+  if (_ctx) {
+    wolfSSL_CTX_free(static_cast<WOLFSSL_CTX*>(_ctx));
+    _ctx = nullptr;
+  }
   _transport.stop();
   _connected = false;
 }
@@ -199,15 +234,39 @@ uint8_t SecureClient::connected() { return _connected && _transport.connected();
 #else  // !FREEINK_NET_WOLFSSL — inert stub so the SDK builds without wolfSSL.
 
 int SecureClient::connect(const char* host, uint16_t port) {
-  (void)host; (void)port;
+  (void)host;
+  (void)port;
   if (Serial) Serial.println("[SecureClient] TLS 1.3 unavailable: build with -DFREEINK_NET_WOLFSSL=1");
   return 0;
 }
-int SecureClient::connect(IPAddress ip, uint16_t port) { (void)ip; (void)port; return 0; }
-size_t SecureClient::write(const uint8_t* buf, size_t size) { (void)buf; (void)size; return 0; }
-int SecureClient::read(uint8_t* buf, size_t size) { (void)buf; (void)size; return -1; }
+int SecureClient::connectWithTimeout(const char* host, uint16_t port, uint32_t timeoutMs,
+                                     const AbortCallback& shouldAbort) {
+  (void)host;
+  (void)port;
+  (void)timeoutMs;
+  (void)shouldAbort;
+  return 0;
+}
+int SecureClient::connect(IPAddress ip, uint16_t port) {
+  (void)ip;
+  (void)port;
+  return 0;
+}
+size_t SecureClient::write(const uint8_t* buf, size_t size) {
+  (void)buf;
+  (void)size;
+  return 0;
+}
+int SecureClient::read(uint8_t* buf, size_t size) {
+  (void)buf;
+  (void)size;
+  return -1;
+}
 int SecureClient::available() { return 0; }
-void SecureClient::stop() { _transport.stop(); _connected = false; }
+void SecureClient::stop() {
+  _transport.stop();
+  _connected = false;
+}
 uint8_t SecureClient::connected() { return 0; }
 
 #endif


### PR DESCRIPTION
## Summary

Add an optional, abort-aware connection API to `SecureClient` and thread `SecureHttpClient` request deadlines through TCP connection setup and TLS negotiation.

## Why

`SecureHttpClient::setTimeout()` previously bounded response processing but not the initial secure connection. `SecureClient` used a fresh hardcoded 15-second TLS deadline for automatic negotiation and another for its TLS 1.2 fallback. A caller with a shorter remaining operation budget could therefore remain blocked well beyond its advertised deadline.

## Changes

- Add `SecureClient::connectWithTimeout()` with one deadline shared by TCP setup, automatic TLS negotiation, and the TLS 1.2 fallback.
- Check an optional abort callback between TLS handshake iterations.
- Make `SecureHttpClient` pass its request timeout and tracked abort callback into secure connection setup.
- Bound plain HTTP TCP connection setup with the same request timeout.
- Preserve the existing `SecureClient::connect()` API and behavior for current callers.
- Preserve `SecureHttpClient::aborted()` classification when cancellation occurs during HTTP or HTTPS connection setup.

## Validation

- CrossPoint ESP32-C3 production firmware build: successful.
- CrossPoint cppcheck: no defects.
- CrossPoint host tests: 143/143 passed.
- Hardware boot validation on an Xteink X4.

## Context

This was developed for an opt-in CrossPoint KOReader automatic-progress upload flow that must finish or enter deep sleep within one bounded background-operation window. The API is general and leaves existing callers unchanged unless they opt into the deadline-aware connection method.

AI tools were used to assist implementation, review, and validation.
