### PR TITLE
feat: allow full-width wrapped list labels

### DIFF
--- a/libs/ui/FreeInkUI/include/components/lists/list.h
+++ b/libs/ui/FreeInkUI/include/components/lists/list.h
@@ -60,6 +60,11 @@ struct ListProps {
   // trailing chevron/value keeps air from the row edge on themes with tight
   // row padding.
   int16_t valueInset = 0;
+  // When a multi-line label would otherwise overlap its trailing value, keep
+  // the wrapped title band visually balanced with that value. Callers with a
+  // short, secondary value (such as a file extension) can disable this to
+  // use the full width remaining before the value.
+  bool balanceWrappedLabelWithValue = true;
   // Switch geometry for ListItem::toggle rows (mirrors ToggleRowProps).
   // Colors derive from the row style's foreground so the switch stays legible
   // on inverted (selected) rows.
@@ -347,7 +352,7 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
                                     props.textGap);
     }
 
-    if (labelStyle.maxLines > 1 && (item.toggle || item.value) && item.label) {
+    if (props.balanceWrappedLabelWithValue && labelStyle.maxLines > 1 && (item.toggle || item.value) && item.label) {
       // A label that fits stays on one line; one that must wrap breaks early
       // (60% of the band) for a balanced two-line split instead of running
       // right up against the trailing slot.

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -556,6 +556,39 @@ void testListClampsBadTopIndex() {
   CHECK_EQ(interactions.data()[3].value, 5);
 }
 
+void testListCanUseFullTitleWidthWithShortValue() {
+  ListItem item{};
+  item.label = "This filename is deliberately long enough to require a two-line wrapped title";
+  item.value = ".epub";
+
+  ListProps props;
+  props.items = &item;
+  props.count = 1;
+  props.rowHeight = 48;
+  props.labelText.maxLines = 2;
+
+  FakeDrawTarget balancedDraw;
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+  InteractionBuffer<4> balancedInteractions;
+  Frame<4> balancedFrame(balancedDraw, device, input, balancedInteractions);
+  list(balancedFrame, Rect{0, 0, 480, 48}, props);
+
+  // Fill, value, then label. The default balanced layout limits a wrapping
+  // title to 60% of the row's text band.
+  CHECK_EQ(balancedDraw.ops[2].rect.width, 278);
+
+  props.balanceWrappedLabelWithValue = false;
+  FakeDrawTarget fullWidthDraw;
+  InteractionBuffer<4> fullWidthInteractions;
+  Frame<4> fullWidthFrame(fullWidthDraw, device, input, fullWidthInteractions);
+  list(fullWidthFrame, Rect{0, 0, 480, 48}, props);
+
+  // Only the extension and its normal gap are reserved, so the title can use
+  // the remaining width before the value.
+  CHECK_EQ(fullWidthDraw.ops[2].rect.width, 424);
+}
+
 void testButtonRegistersExpandedHit() {
   FakeDrawTarget draw;
   DeviceContext device = makeDevice();
@@ -2519,6 +2552,7 @@ int main() {
   testListHelpers();
   testListVirtualization();
   testListClampsBadTopIndex();
+  testListCanUseFullTitleWidthWithShortValue();
   testButtonRegistersExpandedHit();
   testProgressBarClamps();
   testBatteryIndicator();


### PR DESCRIPTION
## Summary

Adds a `ListProps::balanceWrappedLabelWithValue` option for multi-line list rows.

FreeInkUI currently limits wrapped labels to 60% of the title band whenever a row has a trailing value. That works well for settings-style rows with meaningful values, but wastes space when the value is short secondary metadata such as a file extension.

The new option preserves the existing balanced behavior by default. Callers can opt out to let a wrapped label use all width remaining before the trailing value.

## Changes

- Add `balanceWrappedLabelWithValue` to `ListProps`, defaulting to `true`.
- Apply the 60% wrapped-label cap only when that option is enabled.
- Add a host test covering both the existing balanced layout and the full-width opt-out.

## Validation

- `libs/ui/FreeInkUI/test/host/run.sh`

The suite’s new assertions pass. It still reports one existing unrelated failure in `testHeaderBorderEdges` (missing expected divider line), which also occurs on the unmodified SDK baseline.