### PR TITLE
feat: deadline-aware TLS connect and abortable HTTP request writes

### DIFF
--- a/libs/network/SecureNet/include/SecureClient.h
+++ b/libs/network/SecureNet/include/SecureClient.h
@@ -26,6 +26,8 @@ namespace freeink {
 
 class SecureClient : public Client {
  public:
+  using AbortCallback = bool (*)(const void* context);
+
   SecureClient() = default;
   ~SecureClient() override;
 
@@ -36,6 +38,7 @@ class SecureClient : public Client {
   // Connect and perform a TLS 1.3 handshake to host:port (uses the SNI host).
   int connect(IPAddress ip, uint16_t port) override;
   int connect(const char* host, uint16_t port) override;
+  int connect(const char* host, uint16_t port, uint32_t timeoutMs, AbortCallback shouldAbort, const void* abortContext);
 
   size_t write(uint8_t b) override;
   size_t write(const uint8_t* buf, size_t size) override;
@@ -52,7 +55,8 @@ class SecureClient : public Client {
   static bool tls13Available();
 
  private:
-  int connectWithMethod(const char* host, uint16_t port, void* method, const char* label);
+  int connectWithMethod(const char* host, uint16_t port, void* method, const char* label, uint32_t absoluteDeadlineMs,
+                        AbortCallback shouldAbort, const void* abortContext);
 
   WiFiClient _transport;
   const char* _rootCA = nullptr;

--- a/libs/network/SecureNet/include/SecureHttpClient.h
+++ b/libs/network/SecureNet/include/SecureHttpClient.h
@@ -37,10 +37,10 @@
 
 #include <algorithm>
 #include <cctype>
-#include <iterator>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <iterator>
 #include <string>
 #include <utility>
 #include <vector>
@@ -125,6 +125,7 @@ class SecureHttpClient {
   }
 
   int GET() { return sendRequest("GET", nullptr, 0); }
+  int GET(const AbortCallback& shouldAbort) { return sendRequest("GET", nullptr, 0, shouldAbort); }
   int GET(const DataCallback& onData, const AbortCallback& shouldAbort = nullptr) {
     return sendRequest("GET", nullptr, 0, onData, shouldAbort);
   }
@@ -134,16 +135,25 @@ class SecureHttpClient {
   int sendRequest(const char* method, const std::string& payload) {
     return sendRequest(method, reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
   }
+  int sendRequest(const char* method, const std::string& payload, const AbortCallback& shouldAbort) {
+    return sendRequest(method, reinterpret_cast<const uint8_t*>(payload.data()), payload.size(), shouldAbort);
+  }
 
   // Performs the request and reads the full response body. Returns the HTTP
   // status code, or -1 if the connection or status line could not be read. The
   // body (which may be empty or, on a mid-stream drop, truncated) is available
   // via getString().
   int sendRequest(const char* method, const uint8_t* payload, size_t payloadLen) {
-    return sendRequest(method, payload, payloadLen, [this](const uint8_t* data, size_t len) {
-      _body.append(reinterpret_cast<const char*>(data), len);
-      return true;
-    });
+    return sendRequest(method, payload, payloadLen, AbortCallback{});
+  }
+  int sendRequest(const char* method, const uint8_t* payload, size_t payloadLen, const AbortCallback& shouldAbort) {
+    return sendRequest(
+        method, payload, payloadLen,
+        [this](const uint8_t* data, size_t len) {
+          _body.append(reinterpret_cast<const char*>(data), len);
+          return true;
+        },
+        shouldAbort);
   }
 
   // Performs the request and streams the response body to `onData` as chunks
@@ -211,9 +221,9 @@ class SecureHttpClient {
     for (int attempt = 0; attempt < 2; ++attempt) {
       const bool reusing = connectionMatches();
       if (isAborted(shouldAbort)) return -1;
-      if (!ensureConnected()) return -1;
+      if (!ensureConnected(shouldAbort)) return -1;
 
-      if (!writeRequest(method, payload, payloadLen)) {
+      if (!writeRequest(method, payload, payloadLen, shouldAbort)) {
         closeConnection();
         if (reusing && attempt == 0) continue;
         return -1;
@@ -253,8 +263,10 @@ class SecureHttpClient {
         } else if (name == "connection") {
           std::string v = value;
           std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
-          if (v.find("close") != std::string::npos) keepAlive = false;
-          else if (v.find("keep-alive") != std::string::npos) keepAlive = true;
+          if (v.find("close") != std::string::npos)
+            keepAlive = false;
+          else if (v.find("keep-alive") != std::string::npos)
+            keepAlive = true;
         }
       }
       if (_aborted) {
@@ -385,9 +397,7 @@ class SecureHttpClient {
     return !host.empty() && (scheme == "http" || scheme == "https");
   }
 
-  std::string hostHeader() const {
-    return hostHeaderFor(_scheme, _host, _port);
-  }
+  std::string hostHeader() const { return hostHeaderFor(_scheme, _host, _port); }
 
   static std::string hostHeaderFor(const std::string& scheme, const std::string& host, uint16_t port) {
     const uint16_t defaultPort = scheme == "https" ? 443 : 80;
@@ -404,7 +414,13 @@ class SecureHttpClient {
   }
 
   // Reuse the kept-alive connection when it matches, else (re)connect.
-  bool ensureConnected() {
+  static bool secureAbortThunk(const void* context) {
+    const auto* callback = static_cast<const AbortCallback*>(context);
+    return callback && *callback && (*callback)();
+  }
+
+  bool ensureConnected(const AbortCallback& shouldAbort) {
+    if (isAborted(shouldAbort)) return false;
     if (connectionMatches()) return true;
     closeConnection();
     if (_scheme == "https") {
@@ -414,18 +430,21 @@ class SecureHttpClient {
         _secure.setCACert(_rootCA);
       }
       _secure.setTimeout(_timeoutMs / 1000);
-      if (!_secure.connect(_host.c_str(), _port)) return false;
+      if (!_secure.connect(_host.c_str(), _port, _timeoutMs, secureAbortThunk, &shouldAbort)) {
+        if (shouldAbort && shouldAbort()) _aborted = true;
+        return false;
+      }
       _conn = &_secure;
       _connHttps = true;
     } else {
       _plain.setTimeout(_timeoutMs / 1000);
-      if (!_plain.connect(_host.c_str(), _port)) return false;
+      if (!_plain.connect(_host.c_str(), _port, static_cast<int32_t>(_timeoutMs))) return false;
       _conn = &_plain;
       _connHttps = false;
     }
     _connHost = _host;
     _connPort = _port;
-    return true;
+    return !isAborted(shouldAbort);
   }
 
   void closeConnection() {
@@ -440,7 +459,8 @@ class SecureHttpClient {
 
   // Request line + headers (+ body). Write results are checked: a stale
   // keep-alive socket often surfaces first as a failed write.
-  bool writeRequest(const char* method, const uint8_t* payload, size_t payloadLen) {
+  bool writeRequest(const char* method, const uint8_t* payload, size_t payloadLen,
+                    const AbortCallback& shouldAbort = nullptr) {
     std::string req = std::string(method) + " " + _path + " HTTP/1.1\r\nHost: " + hostHeader() + "\r\n";
     req += "User-Agent: " + _userAgent + "\r\n";
     req += _reuse ? "Connection: keep-alive\r\n" : "Connection: close\r\n";
@@ -451,8 +471,23 @@ class SecureHttpClient {
     for (const std::string& h : _headers) req += h;
     if (payload && payloadLen) req += "Content-Length: " + std::to_string(payloadLen) + "\r\n";
     req += "\r\n";
-    if (_conn->write(reinterpret_cast<const uint8_t*>(req.data()), req.size()) != req.size()) return false;
-    if (payload && payloadLen && _conn->write(payload, payloadLen) != payloadLen) return false;
+    if (!writeAll(reinterpret_cast<const uint8_t*>(req.data()), req.size(), shouldAbort)) return false;
+    if (payload && payloadLen && !writeAll(payload, payloadLen, shouldAbort)) return false;
+    return true;
+  }
+
+  // Chunked writes keep a large body interruptible: the abort callback is
+  // checked between chunks so a stalled socket cannot hold the caller past an
+  // absolute deadline for longer than one chunk's send.
+  bool writeAll(const uint8_t* data, size_t len, const AbortCallback& shouldAbort) {
+    constexpr size_t WRITE_CHUNK = 1024;
+    size_t offset = 0;
+    while (offset < len) {
+      if (isAborted(shouldAbort)) return false;
+      const size_t chunk = len - offset < WRITE_CHUNK ? len - offset : WRITE_CHUNK;
+      if (_conn->write(data + offset, chunk) != chunk) return false;
+      offset += chunk;
+    }
     return true;
   }
 

--- a/libs/network/SecureNet/src/SecureClient.cpp
+++ b/libs/network/SecureNet/src/SecureClient.cpp
@@ -55,7 +55,9 @@ bool isWantIo(const int err) {
 }
 }  // namespace
 
-int SecureClient::connectWithMethod(const char* host, uint16_t port, void* method, const char* label) {
+int SecureClient::connectWithMethod(const char* host, uint16_t port, void* method, const char* label,
+                                    const uint32_t absoluteDeadlineMs, const AbortCallback shouldAbort,
+                                    const void* abortContext) {
 #if defined(FREEINK_WOLFSSL_DEBUG)
   // Routes wolfSSL's internal trace through wolfSSL_Arduino_Serial_Print (the
   // application provides that hook). Shows exactly where a handshake stalls.
@@ -67,14 +69,19 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
 #endif
   const uint32_t started = millis();
   stop();
-  if (!_transport.connect(host, port)) {
+  if ((shouldAbort && shouldAbort(abortContext)) || static_cast<int32_t>(absoluteDeadlineMs - millis()) <= 0) {
+    return 0;
+  }
+  const uint32_t tcpTimeoutMs = absoluteDeadlineMs - millis();
+  if (!_transport.connect(host, port, static_cast<int32_t>(tcpTimeoutMs))) {
     if (Serial) Serial.printf("[SecureClient] TCP connect failed (%s): %s:%u\n", label, host, port);
     return 0;
   }
 
   auto* ctx = wolfSSL_CTX_new(static_cast<WOLFSSL_METHOD*>(method));
   if (!ctx) {
-    if (Serial) Serial.printf("[SecureClient] CTX alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
+    if (Serial)
+      Serial.printf("[SecureClient] CTX alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
     _transport.stop();
     return 0;
   }
@@ -83,15 +90,16 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   if (_insecure) {
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, nullptr);
   } else if (_rootCA) {
-    wolfSSL_CTX_load_verify_buffer(ctx, reinterpret_cast<const unsigned char*>(_rootCA),
-                                   strlen(_rootCA), WOLFSSL_FILETYPE_PEM);
+    wolfSSL_CTX_load_verify_buffer(ctx, reinterpret_cast<const unsigned char*>(_rootCA), strlen(_rootCA),
+                                   WOLFSSL_FILETYPE_PEM);
   }
   wolfSSL_SetIORecv(ctx, wcRecv);
   wolfSSL_SetIOSend(ctx, wcSend);
 
   auto* ssl = wolfSSL_new(ctx);
   if (!ssl) {
-    if (Serial) Serial.printf("[SecureClient] SSL alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
+    if (Serial)
+      Serial.printf("[SecureClient] SSL alloc failed (%s), free heap %u\n", label, (unsigned)ESP.getFreeHeap());
     stop();
     return 0;
   }
@@ -113,7 +121,6 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   // The recv callback is non-blocking (returns WANT_READ when no bytes are
   // buffered), so wolfSSL_connect must be retried across handshake round-trips
   // rather than called once.
-  const uint32_t deadline = millis() + 15000;
   int ret;
   while ((ret = wolfSSL_connect(ssl)) != WOLFSSL_SUCCESS) {
     const int err = wolfSSL_get_error(ssl, ret);
@@ -122,7 +129,7 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
       stop();
       return 0;
     }
-    if (static_cast<int32_t>(millis() - deadline) >= 0) {
+    if ((shouldAbort && shouldAbort(abortContext)) || static_cast<int32_t>(millis() - absoluteDeadlineMs) >= 0) {
       if (Serial) {
         Serial.printf("[SecureClient] handshake timeout (%s): last err %d, transport %s, free heap %u\n", label, err,
                       _transport.connected() ? "up" : "down", (unsigned)ESP.getFreeHeap());
@@ -140,18 +147,31 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   return 1;
 }
 
-int SecureClient::connect(const char* host, uint16_t port) {
+int SecureClient::connect(const char* host, uint16_t port) { return connect(host, port, 15000, nullptr, nullptr); }
+
+int SecureClient::connect(const char* host, uint16_t port, const uint32_t timeoutMs, const AbortCallback shouldAbort,
+                          const void* abortContext) {
+  if (timeoutMs == 0) return 0;
+  const uint32_t absoluteDeadlineMs = millis() + timeoutMs;
   // Negotiate the highest mutually supported version rather than pinning TLS 1.3:
   // self-hosted / Let's Encrypt nginx often tops out at TLS 1.2, and a 1.3-only
   // client fails those handshakes outright. v23 still selects 1.3 when the peer
   // offers it (WOLFSSL_TLS13 is enabled) and falls back to 1.2 otherwise.
-  if (connectWithMethod(host, port, wolfSSLv23_client_method(), "auto")) return 1;
+  if (connectWithMethod(host, port, wolfSSLv23_client_method(), "auto", absoluteDeadlineMs, shouldAbort,
+                        abortContext)) {
+    return 1;
+  }
+
+  if ((shouldAbort && shouldAbort(abortContext)) || static_cast<int32_t>(absoluteDeadlineMs - millis()) <= 0) {
+    return 0;
+  }
 
   // Some TLS 1.2-only servers are intolerant of a TLS 1.3-capable ClientHello
   // and abort with a fatal handshake_failure alert. Retry with an explicit
   // TLS 1.2 ClientHello before giving up.
   if (Serial) Serial.println("[SecureClient] retrying with TLS 1.2-only handshake");
-  return connectWithMethod(host, port, wolfTLSv1_2_client_method(), "tls1.2");
+  return connectWithMethod(host, port, wolfTLSv1_2_client_method(), "tls1.2", absoluteDeadlineMs, shouldAbort,
+                           abortContext);
 }
 
 int SecureClient::connect(IPAddress ip, uint16_t port) {
@@ -188,8 +208,14 @@ int SecureClient::available() {
 }
 
 void SecureClient::stop() {
-  if (_ssl) { wolfSSL_free(static_cast<WOLFSSL*>(_ssl)); _ssl = nullptr; }
-  if (_ctx) { wolfSSL_CTX_free(static_cast<WOLFSSL_CTX*>(_ctx)); _ctx = nullptr; }
+  if (_ssl) {
+    wolfSSL_free(static_cast<WOLFSSL*>(_ssl));
+    _ssl = nullptr;
+  }
+  if (_ctx) {
+    wolfSSL_CTX_free(static_cast<WOLFSSL_CTX*>(_ctx));
+    _ctx = nullptr;
+  }
   _transport.stop();
   _connected = false;
 }
@@ -199,15 +225,37 @@ uint8_t SecureClient::connected() { return _connected && _transport.connected();
 #else  // !FREEINK_NET_WOLFSSL — inert stub so the SDK builds without wolfSSL.
 
 int SecureClient::connect(const char* host, uint16_t port) {
-  (void)host; (void)port;
+  (void)host;
+  (void)port;
   if (Serial) Serial.println("[SecureClient] TLS 1.3 unavailable: build with -DFREEINK_NET_WOLFSSL=1");
   return 0;
 }
-int SecureClient::connect(IPAddress ip, uint16_t port) { (void)ip; (void)port; return 0; }
-size_t SecureClient::write(const uint8_t* buf, size_t size) { (void)buf; (void)size; return 0; }
-int SecureClient::read(uint8_t* buf, size_t size) { (void)buf; (void)size; return -1; }
+int SecureClient::connect(const char* host, uint16_t port, uint32_t timeoutMs, AbortCallback shouldAbort,
+                          const void* abortContext) {
+  (void)timeoutMs;
+  if (shouldAbort && shouldAbort(abortContext)) return 0;
+  return connect(host, port);
+}
+int SecureClient::connect(IPAddress ip, uint16_t port) {
+  (void)ip;
+  (void)port;
+  return 0;
+}
+size_t SecureClient::write(const uint8_t* buf, size_t size) {
+  (void)buf;
+  (void)size;
+  return 0;
+}
+int SecureClient::read(uint8_t* buf, size_t size) {
+  (void)buf;
+  (void)size;
+  return -1;
+}
 int SecureClient::available() { return 0; }
-void SecureClient::stop() { _transport.stop(); _connected = false; }
+void SecureClient::stop() {
+  _transport.stop();
+  _connected = false;
+}
 uint8_t SecureClient::connected() { return 0; }
 
 #endif


### PR DESCRIPTION
## Summary

Allows callers to bound SecureNet operations with an absolute deadline, needed by CrossPoint Reader's upcoming automatic sleep progress sync (which must guarantee the device reaches deep sleep within a fixed time budget even if the network stalls).

- `SecureClient::connect()` gains an overload taking a timeout plus an abort callback (plain function pointer + context, no `std::function` in the TLS layer). The TCP connect, the wolfSSL handshake retry loop, and the TLS 1.2 fallback attempt all honor the same absolute deadline instead of the previous fixed internal 15 s bound.
- `SecureHttpClient::GET`/`sendRequest` gain `AbortCallback` overloads that thread the existing abort check into connection establishment and request writing. Request headers and body are written in 1 KB chunks with an abort check between chunks, so a stalled socket cannot hold the caller past its deadline for longer than one chunk's send.

## Compatibility

Behavior without the new parameters is unchanged: `connect(host, port)` keeps the 15 s default, and requests remain non-abortable unless a callback is passed. No existing call sites change.

## Testing

- Exercised end-to-end on X4 hardware by CrossPoint's sleep sync branch (crosspoint-reader PR to follow): TLS 1.3 handshakes against sync.koreader.rocks complete in 360-760 ms under the deadline, and deadline expiry during connect/read/write aborts cleanly.
- Builds with and without `FREEINK_NET_WOLFSSL` (the stub implements the new overload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8difUA42fKkr3Qj11bMEN