### PR TITLE
feat(keyboard): multilingual layouts and a script-switch key

### DIFF
--- a/libs/ui/FreeInkUI/include/components/keyboard/key-grid.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/key-grid.h
@@ -14,6 +14,11 @@ enum class KeyKind : uint8_t {
   Delete,
   Ok,
   Disabled,
+  // Switches to the next enabled script layout (Latin <-> Cyrillic <-> ...).
+  // Distinct from Mode, which pages between letters and symbols within one
+  // script. The label is always supplied by the app through KeyboardProps:
+  // it names the layout the key leads to, which the static tables cannot know.
+  Lang,
 };
 
 struct KeyGridKey {

--- a/libs/ui/FreeInkUI/include/components/keyboard/key-grid.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/key-grid.h
@@ -16,8 +16,8 @@ enum class KeyKind : uint8_t {
   Disabled,
   // Switches to the next enabled script layout (Latin <-> Cyrillic <-> ...).
   // Distinct from Mode, which pages between letters and symbols within one
-  // script. The label is always supplied by the app through KeyboardProps:
-  // it names the layout the key leads to, which the static tables cannot know.
+  // script. The label is always supplied by the app through KeyboardProps,
+  // since which layout is active is app state the static tables cannot know.
   Lang,
 };
 

--- a/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
@@ -9,15 +9,25 @@ namespace ui {
 
 constexpr int16_t QWERTY_KEY_SHIFT = -1;
 constexpr int16_t QWERTY_KEY_MODE = -2;
+// -3 is taken by app-defined keys downstream (CrossPoint's URL panel toggle),
+// so the script switch takes -4.
+constexpr int16_t QWERTY_KEY_LANG = -4;
 constexpr int16_t QWERTY_KEY_BACKSPACE = 8;
 constexpr int16_t QWERTY_KEY_ENTER = 13;
 constexpr int16_t QWERTY_KEY_SPACE = 32;
 
+// Layouts are grouped by script. A build ships all of them in flash; which ones
+// a user can reach is the app's decision, so nothing here assumes a pairing
+// between UI language and available layouts.
 enum class KeyboardLayoutId : uint8_t {
   QwertyEn,
   AzertyFr,
   QwertzDe,
   SpanishEs,
+  // ЙЦУКЕН. Ships as two explicit layers (shift picks between them) because
+  // Cyrillic has no single-key case toggle the way the Latin layouts do; the
+  // long-press case flip is handled by keyboardAltOutputFor.
+  CyrillicRu,
 };
 
 struct KeyboardKey {
@@ -49,6 +59,7 @@ struct KeyboardProps {
   ActionId keyAction = NO_ACTION;
   ActionId shiftAction = NO_ACTION;
   ActionId modeAction = NO_ACTION;
+  ActionId langAction = NO_ACTION;
   ActionId deleteAction = NO_ACTION;
   ActionId okAction = NO_ACTION;
   // Optional localized labels for KeyKind::Ok / Shift / Mode keys. Layout
@@ -59,6 +70,11 @@ struct KeyboardProps {
   const char* okLabel = nullptr;
   const char* shiftLabel = nullptr;
   const char* modeLabel = nullptr;
+  // KeyKind::Lang has no sensible table label: it names the layout the key
+  // leads to, and with more than two layouts enabled that is whatever comes
+  // next in the app's cycle. Always supplied per frame; a Lang key with no
+  // label falls back to the table's, which the built-in tables leave as "EN".
+  const char* langLabel = nullptr;
   uint16_t inputMask = InputDefault;
   int16_t selectedIndex = -1;
   TextStyle labelText{};
@@ -83,9 +99,16 @@ struct KeyboardProps {
 // long-press) to the letter layers — for entry fields where digits must stay
 // one tap away (passwords, hosts, ports). The symbol layers already carry
 // digits, so they ignore the flag. Shift swaps the row to symbols-primary on
-// QwertyEn; the other languages keep their single letter layer.
+// QwertyEn and picks the uppercase layer on CyrillicRu; FR/DE/ES keep their
+// single letter layer.
+//
+// `langKey` puts a KeyKind::Lang key in the bottom row, for apps that let the
+// user reach more than one script. It costs a slot in that row, so it is off by
+// default and single-script keyboards render exactly as before. CyrillicRu
+// ignores the flag and always carries the key: a Cyrillic-only keyboard cannot
+// type a Wi-Fi password or a URL, so there always has to be a way back.
 const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted = false, bool symbols = false,
-                                            bool numberRow = false);
+                                            bool numberRow = false, bool langKey = false);
 
 // The UTF-8 text a key id inserts under the given layout (nullptr for
 // shift/mode/delete/OK and unknown ids). Keys report stable ids in
@@ -95,10 +118,11 @@ const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted = 
 const char* keyboardOutputFor(const KeyboardLayout& layout, int16_t value);
 
 // The UTF-8 alternate a key id inserts on long-press. Explicit KeyboardKey::alt
-// wins; ASCII letter keys without one fall back to the opposite case (the
-// phone-keyboard hold-for-capital convention). Returns nullptr when the key
-// has no alternate. The case-flip result lives in a static buffer — call from
-// one task (the UI loop), and consume before the next call.
+// wins; letter keys without one fall back to the opposite case (the
+// phone-keyboard hold-for-capital convention) — ASCII a-z/A-Z and Cyrillic
+// U+0410..U+044F plus Ё/ё. Returns nullptr when the key has no alternate. The
+// case-flip result lives in a static buffer — call from one task (the UI loop),
+// and consume before the next call.
 const char* keyboardAltOutputFor(const KeyboardLayout& layout, int16_t value);
 
 // Touch hold routing for e-paper keyboards: fires the long-press at the
@@ -325,6 +349,7 @@ void keyboard(Frame<MaxInteractions>& frame, Rect rect, const KeyboardProps& pro
   auto actionFor = [&](KeyKind kind) {
     if (kind == KeyKind::Shift && props.shiftAction != NO_ACTION) return props.shiftAction;
     if (kind == KeyKind::Mode && props.modeAction != NO_ACTION) return props.modeAction;
+    if (kind == KeyKind::Lang && props.langAction != NO_ACTION) return props.langAction;
     if (kind == KeyKind::Delete && props.deleteAction != NO_ACTION) return props.deleteAction;
     if (kind == KeyKind::Ok && props.okAction != NO_ACTION) return props.okAction;
     return props.keyAction;
@@ -341,6 +366,7 @@ void keyboard(Frame<MaxInteractions>& frame, Rect rect, const KeyboardProps& pro
     if (key.kind == KeyKind::Ok && props.okLabel) bp.label = props.okLabel;
     if (key.kind == KeyKind::Shift && props.shiftLabel) bp.label = props.shiftLabel;
     if (key.kind == KeyKind::Mode && props.modeLabel) bp.label = props.modeLabel;
+    if (key.kind == KeyKind::Lang && props.langLabel) bp.label = props.langLabel;
     bp.action = action;
     bp.value = key.value;
     bp.inputMask = props.inputMask;

--- a/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
@@ -80,9 +80,8 @@ struct KeyboardProps {
   const char* okLabel = nullptr;
   const char* shiftLabel = nullptr;
   const char* modeLabel = nullptr;
-  // KeyKind::Lang has no sensible table label: it names the layout the key
-  // leads to, and with more than two layouts enabled that is whatever comes
-  // next in the app's cycle. Always supplied per frame; a Lang key with no
+  // KeyKind::Lang has no sensible table label: which layout is in use is the
+  // app's state, not the table's. Always supplied per frame; a Lang key with no
   // label falls back to the table's, which the built-in tables leave as "EN".
   const char* langLabel = nullptr;
   uint16_t inputMask = InputDefault;

--- a/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
@@ -109,14 +109,15 @@ struct KeyboardProps {
 // long-press) to the letter layers — for entry fields where digits must stay
 // one tap away (passwords, hosts, ports). The symbol layers already carry
 // digits, so they ignore the flag. Shift swaps the row to symbols-primary on
-// QwertyEn and picks the uppercase layer on CyrillicRu; FR/DE/ES keep their
-// single letter layer.
+// QwertyEn and picks the uppercase layer on the Cyrillic layouts; FR/DE/ES keep
+// their single letter layer, and HebrewIl has no case at all.
 //
 // `langKey` puts a KeyKind::Lang key in the bottom row, for apps that let the
 // user reach more than one script. It costs a slot in that row, so it is off by
-// default and single-script keyboards render exactly as before. CyrillicRu
-// ignores the flag and always carries the key: a Cyrillic-only keyboard cannot
-// type a Wi-Fi password or a URL, so there always has to be a way back.
+// default and single-script keyboards render exactly as before. The non-Latin
+// layouts ignore the flag and always carry the key: a keyboard with no Latin
+// letters cannot type a Wi-Fi password or a URL, so there always has to be a
+// way back.
 const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted = false, bool symbols = false,
                                             bool numberRow = false, bool langKey = false);
 

--- a/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
@@ -24,10 +24,20 @@ enum class KeyboardLayoutId : uint8_t {
   AzertyFr,
   QwertzDe,
   SpanishEs,
-  // ЙЦУКЕН. Ships as two explicit layers (shift picks between them) because
-  // Cyrillic has no single-key case toggle the way the Latin layouts do; the
-  // long-press case flip is handled by keyboardAltOutputFor.
+  // ЙЦУКЕН family. Each ships as two explicit layers (shift picks between them)
+  // because Cyrillic has no single-key case toggle the way the Latin layouts
+  // do; the long-press case flip is handled by keyboardAltOutputFor.
+  //
+  // The four differ only in which letters occupy a handful of slots. Ukrainian
+  // reaches ґ, and Kazakh its nine extra letters, by long-press rather than
+  // dedicated keys — a 480px panel has no room for a wider grid.
   CyrillicRu,
+  CyrillicUk,
+  CyrillicBe,
+  CyrillicKk,
+  // Hebrew: no letter case, so a single layer and no shift key. Right-to-left
+  // is the renderer's job -- the layout inserts code points in logical order.
+  HebrewIl,
 };
 
 struct KeyboardKey {

--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -222,6 +222,73 @@ static const KeyboardKey ES_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHI
                                       K("n", "n", 'n'), K("m", "m", 'm'),
                                       KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
 
+// ЙЦУКЕН. Key ids are the letters' code points (U+0410..U+044F): they fit
+// int16_t and stay clear of the ASCII ids and the negative control ids.
+//
+// They do overlap the localized-letter ids of the Latin layouts — э is 0x44D,
+// which is 1101, the same number as QwertzDe's ü. That is safe because ids are
+// only ever resolved within one layout (keyboardOutputFor walks the layout it
+// is handed), and two scripts are never on screen at once. Anything that maps
+// an id to a character without knowing the layout would break, which is exactly
+// why keyboardOutputFor takes the layout as its first argument.
+//
+// Keys carry no explicit `alt`, so long-press falls through to the implicit
+// case flip in keyboardAltOutputFor, exactly as the Latin layouts do. Spelling
+// the opposite case out would also make the renderer draw it as a corner hint,
+// putting "йЙ" on every key.
+//
+// The one deliberate `alt` is е/Е → ё/Ё: that letter has no key of its own in
+// this arrangement, so the hint is worth showing and the flip is worth losing.
+static const KeyboardKey RU_ROW1[] = {K("й", "й", 0x439), K("ц", "ц", 0x446), K("у", "у", 0x443),
+                                      K("к", "к", 0x43A), KA("е", "е", 0x435, "ё"), K("н", "н", 0x43D),
+                                      K("г", "г", 0x433), K("ш", "ш", 0x448), K("щ", "щ", 0x449),
+                                      K("з", "з", 0x437), K("х", "х", 0x445), K("ъ", "ъ", 0x44A)};
+static const KeyboardKey RU_ROW2[] = {K("ф", "ф", 0x444), K("ы", "ы", 0x44B), K("в", "в", 0x432),
+                                      K("а", "а", 0x430), K("п", "п", 0x43F), K("р", "р", 0x440),
+                                      K("о", "о", 0x43E), K("л", "л", 0x43B), K("д", "д", 0x434),
+                                      K("ж", "ж", 0x436), K("э", "э", 0x44D)};
+static const KeyboardKey RU_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                      K("я", "я", 0x44F),
+                                      K("ч", "ч", 0x447),
+                                      K("с", "с", 0x441),
+                                      K("м", "м", 0x43C),
+                                      K("и", "и", 0x438),
+                                      K("т", "т", 0x442),
+                                      K("ь", "ь", 0x44C),
+                                      K("б", "б", 0x431),
+                                      K("ю", "ю", 0x44E),
+                                      KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey RU_SHIFT_ROW1[] = {
+    K("Й", "Й", 0x419), K("Ц", "Ц", 0x426), K("У", "У", 0x423), K("К", "К", 0x41A),
+    KA("Е", "Е", 0x415, "Ё"), K("Н", "Н", 0x41D), K("Г", "Г", 0x413), K("Ш", "Ш", 0x428),
+    K("Щ", "Щ", 0x429), K("З", "З", 0x417), K("Х", "Х", 0x425), K("Ъ", "Ъ", 0x42A)};
+static const KeyboardKey RU_SHIFT_ROW2[] = {
+    K("Ф", "Ф", 0x424), K("Ы", "Ы", 0x42B), K("В", "В", 0x412), K("А", "А", 0x410),
+    K("П", "П", 0x41F), K("Р", "Р", 0x420), K("О", "О", 0x41E), K("Л", "Л", 0x41B),
+    K("Д", "Д", 0x414), K("Ж", "Ж", 0x416), K("Э", "Э", 0x42D)};
+static const KeyboardKey RU_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                            K("Я", "Я", 0x42F),
+                                            K("Ч", "Ч", 0x427),
+                                            K("С", "С", 0x421),
+                                            K("М", "М", 0x41C),
+                                            K("И", "И", 0x418),
+                                            K("Т", "Т", 0x422),
+                                            K("Ь", "Ь", 0x42C),
+                                            K("Б", "Б", 0x411),
+                                            K("Ю", "Ю", 0x42E),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+// Bottom row carrying the script-switch key. Kept separate from EN_ROW4 so a
+// single-script build renders exactly as before — the key costs a slot in the
+// row, and there is no point spending it when there is nowhere to switch to.
+// Its "EN" label is a placeholder: the app overrides it per frame through
+// KeyboardProps::langLabel with the name of whatever layout comes next.
+static const KeyboardKey LANG_ROW4[] = {KS("?123", KeyKind::Mode, QWERTY_KEY_MODE, 2),
+                                        KS("EN", KeyKind::Lang, QWERTY_KEY_LANG, 2),
+                                        KS("Space", KeyKind::Space, QWERTY_KEY_SPACE, 4),
+                                        KS("OK", KeyKind::Ok, QWERTY_KEY_ENTER, 2)};
+
 static const KeyboardRow EN_ROWS[] = {{EN_ROW1, 10, 0}, {EN_ROW2, 9, 1}, {EN_ROW3, 9, 0}, {EN_ROW4, 3, 0}};
 static const KeyboardRow EN_SHIFT_ROWS[] = {{EN_SHIFT_ROW1, 10, 0}, {EN_SHIFT_ROW2, 9, 1}, {EN_SHIFT_ROW3, 9, 0},
                                            {EN_ROW4, 3, 0}};
@@ -259,6 +326,53 @@ static const KeyboardLayout FR_NUM_LAYOUT{FR_NUM_ROWS, 5};
 static const KeyboardLayout DE_NUM_LAYOUT{DE_NUM_ROWS, 5};
 static const KeyboardLayout ES_NUM_LAYOUT{ES_NUM_ROWS, 5};
 
+// Cyrillic ships only in the lang-key flavour: a Cyrillic-only keyboard cannot
+// type a Wi-Fi password or a URL, so there always has to be a way back to
+// Latin. Its rows run 12/11/11 keys against Latin's 10/9/9 — callers sizing a
+// hit-test buffer from the widest layout must account for that.
+static const KeyboardRow RU_ROWS[] = {{RU_ROW1, 12, 0}, {RU_ROW2, 11, 0}, {RU_ROW3, 11, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow RU_SHIFT_ROWS[] = {{RU_SHIFT_ROW1, 12, 0},
+                                            {RU_SHIFT_ROW2, 11, 0},
+                                            {RU_SHIFT_ROW3, 11, 0},
+                                            {LANG_ROW4, 4, 0}};
+static const KeyboardRow RU_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                          {RU_ROW1, 12, 0},
+                                          {RU_ROW2, 11, 0},
+                                          {RU_ROW3, 11, 0},
+                                          {LANG_ROW4, 4, 0}};
+static const KeyboardRow RU_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
+                                                {RU_SHIFT_ROW1, 12, 0},
+                                                {RU_SHIFT_ROW2, 11, 0},
+                                                {RU_SHIFT_ROW3, 11, 0},
+                                                {LANG_ROW4, 4, 0}};
+
+// Latin layers wearing the lang-key bottom row, so a multi-script keyboard can
+// switch back. Letter rows are the plain EN tables — same QWERTY, no copies.
+static const KeyboardRow EN_LANG_ROWS[] = {{EN_ROW1, 10, 0}, {EN_ROW2, 9, 1}, {EN_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow EN_SHIFT_LANG_ROWS[] = {{EN_SHIFT_ROW1, 10, 0},
+                                                 {EN_SHIFT_ROW2, 9, 1},
+                                                 {EN_SHIFT_ROW3, 9, 0},
+                                                 {LANG_ROW4, 4, 0}};
+static const KeyboardRow EN_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                               {EN_ROW1, 10, 0},
+                                               {EN_ROW2, 9, 1},
+                                               {EN_ROW3, 9, 0},
+                                               {LANG_ROW4, 4, 0}};
+static const KeyboardRow EN_SHIFT_LANG_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
+                                                     {EN_SHIFT_ROW1, 10, 0},
+                                                     {EN_SHIFT_ROW2, 9, 1},
+                                                     {EN_SHIFT_ROW3, 9, 0},
+                                                     {LANG_ROW4, 4, 0}};
+
+static const KeyboardLayout RU_LAYOUT{RU_ROWS, 4};
+static const KeyboardLayout RU_SHIFT_LAYOUT{RU_SHIFT_ROWS, 4};
+static const KeyboardLayout RU_NUM_LAYOUT{RU_NUM_ROWS, 5};
+static const KeyboardLayout RU_SHIFT_NUM_LAYOUT{RU_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout EN_LANG_LAYOUT{EN_LANG_ROWS, 4};
+static const KeyboardLayout EN_SHIFT_LANG_LAYOUT{EN_SHIFT_LANG_ROWS, 4};
+static const KeyboardLayout EN_LANG_NUM_LAYOUT{EN_LANG_NUM_ROWS, 5};
+static const KeyboardLayout EN_SHIFT_LANG_NUM_LAYOUT{EN_SHIFT_LANG_NUM_ROWS, 5};
+
 #undef K
 #undef K2
 #undef KS
@@ -266,12 +380,23 @@ static const KeyboardLayout ES_NUM_LAYOUT{ES_NUM_ROWS, 5};
 
 }  // namespace
 
-const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted, bool symbols, bool numberRow) {
+const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted, bool symbols, bool numberRow,
+                                            bool langKey) {
   // In the symbols layers `shifted` selects the second page: the shift slot
   // reads "#+=" on page one and "123" on page two, mirroring phone keyboards.
   // The symbols pages already carry digits, so numberRow only affects the
   // letter layers.
   if (symbols) return shifted ? SYMBOL2_LAYOUT : SYMBOL_LAYOUT;
+  // Cyrillic is case-explicit: both layers exist and shift picks between them,
+  // unlike FR/DE/ES which keep a single letter layer.
+  if (id == KeyboardLayoutId::CyrillicRu) {
+    if (shifted) return numberRow ? RU_SHIFT_NUM_LAYOUT : RU_SHIFT_LAYOUT;
+    return numberRow ? RU_NUM_LAYOUT : RU_LAYOUT;
+  }
+  if (id == KeyboardLayoutId::QwertyEn && langKey) {
+    if (shifted) return numberRow ? EN_SHIFT_LANG_NUM_LAYOUT : EN_SHIFT_LANG_LAYOUT;
+    return numberRow ? EN_LANG_NUM_LAYOUT : EN_LANG_LAYOUT;
+  }
   if (shifted && id == KeyboardLayoutId::QwertyEn) return numberRow ? EN_SHIFT_NUM_LAYOUT : EN_SHIFT_LAYOUT;
   switch (id) {
     case KeyboardLayoutId::AzertyFr:
@@ -307,15 +432,31 @@ const char* keyboardAltOutputFor(const KeyboardLayout& layout, int16_t value) {
       if (key.value != value) continue;
       if (key.kind != KeyKind::Normal) return nullptr;
       if (key.alt) return key.alt;
-      // ASCII letters without an explicit alt flip case (hold-for-capital).
-      // Static buffer: single UI-loop caller assumption (see header doc).
-      static char flipped[2] = {0, 0};
+      // Letters without an explicit alt flip case (hold-for-capital).
+      // Static buffer: single UI-loop caller assumption (see header doc). Three
+      // bytes because Cyrillic encodes to two in UTF-8, plus the terminator.
+      static char flipped[3] = {0, 0, 0};
       if (value >= 'a' && value <= 'z') {
         flipped[0] = static_cast<char>(value - ('a' - 'A'));
+        flipped[1] = 0;
         return flipped;
       }
       if (value >= 'A' && value <= 'Z') {
         flipped[0] = static_cast<char>(value + ('a' - 'A'));
+        flipped[1] = 0;
+        return flipped;
+      }
+      // Cyrillic: А-Я is U+0410..U+042F and а-я is U+0430..U+044F, the same
+      // 0x20 offset as ASCII. Ё/ё sit outside that block at U+0401/U+0451.
+      int32_t cp = -1;
+      if (value >= 0x0410 && value <= 0x042F) cp = value + 0x20;
+      if (value >= 0x0430 && value <= 0x044F) cp = value - 0x20;
+      if (value == 0x0401) cp = 0x0451;
+      if (value == 0x0451) cp = 0x0401;
+      if (cp > 0) {
+        // Two-byte UTF-8: 110xxxxx 10xxxxxx.
+        flipped[0] = static_cast<char>(0xC0 | (cp >> 6));
+        flipped[1] = static_cast<char>(0x80 | (cp & 0x3F));
         return flipped;
       }
       return nullptr;

--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -279,6 +279,167 @@ static const KeyboardKey RU_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_K
                                             K("Ю", "Ю", 0x42E),
                                             KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
 
+// Ukrainian ЙЦУКЕН. Differs from Russian in four slots: ї replaces ъ, і
+// replaces ы, є replaces э, and и is the Ukrainian и (U+0438) as in Russian
+// while й stays put. ґ has no key of its own — it long-presses off г, the
+// letter it derives from, mirroring how ё hangs off е in the Russian layer.
+// The apostrophe is a real letter-level separator in Ukrainian, so it takes
+// the slot Russian gives to ъ's neighbour.
+static const KeyboardKey UK_ROW1[] = {K("й", "й", 0x439), K("ц", "ц", 0x446),  K("у", "у", 0x443),
+                                      KA("г", "г", 0x433, "ґ"), K("к", "к", 0x43A), K("е", "е", 0x435),
+                                      K("н", "н", 0x43D), K("ш", "ш", 0x448),  K("щ", "щ", 0x449),
+                                      K("з", "з", 0x437), K("х", "х", 0x445),  K("ї", "ї", 0x457)};
+static const KeyboardKey UK_ROW2[] = {K("ф", "ф", 0x444), K("і", "і", 0x456), K("в", "в", 0x432),
+                                      K("а", "а", 0x430), K("п", "п", 0x43F), K("р", "р", 0x440),
+                                      K("о", "о", 0x43E), K("л", "л", 0x43B), K("д", "д", 0x434),
+                                      K("ж", "ж", 0x436), K("є", "є", 0x454)};
+static const KeyboardKey UK_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                      K("я", "я", 0x44F),
+                                      K("ч", "ч", 0x447),
+                                      K("с", "с", 0x441),
+                                      K("м", "м", 0x43C),
+                                      K("и", "и", 0x438),
+                                      K("т", "т", 0x442),
+                                      K("ь", "ь", 0x44C),
+                                      K("б", "б", 0x431),
+                                      K("ю", "ю", 0x44E),
+                                      KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey UK_SHIFT_ROW1[] = {K("Й", "Й", 0x419),        K("Ц", "Ц", 0x426), K("У", "У", 0x423),
+                                            KA("Г", "Г", 0x413, "Ґ"),  K("К", "К", 0x41A), K("Е", "Е", 0x415),
+                                            K("Н", "Н", 0x41D),        K("Ш", "Ш", 0x428), K("Щ", "Щ", 0x429),
+                                            K("З", "З", 0x417),        K("Х", "Х", 0x425), K("Ї", "Ї", 0x407)};
+static const KeyboardKey UK_SHIFT_ROW2[] = {K("Ф", "Ф", 0x424), K("І", "І", 0x406), K("В", "В", 0x412),
+                                            K("А", "А", 0x410), K("П", "П", 0x41F), K("Р", "Р", 0x420),
+                                            K("О", "О", 0x41E), K("Л", "Л", 0x41B), K("Д", "Д", 0x414),
+                                            K("Ж", "Ж", 0x416), K("Є", "Є", 0x404)};
+static const KeyboardKey UK_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                            K("Я", "Я", 0x42F),
+                                            K("Ч", "Ч", 0x427),
+                                            K("С", "С", 0x421),
+                                            K("М", "М", 0x41C),
+                                            K("И", "И", 0x418),
+                                            K("Т", "Т", 0x422),
+                                            K("Ь", "Ь", 0x42C),
+                                            K("Б", "Б", 0x411),
+                                            K("Ю", "Ю", 0x42E),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+// Belarusian ЙЦУКЕН. Against Russian: ў replaces щ, і replaces и, and there is
+// no ъ (its job is done by the apostrophe, which sits where ъ would be).
+static const KeyboardKey BE_ROW1[] = {K("й", "й", 0x439), K("ц", "ц", 0x446), K("у", "у", 0x443),
+                                      K("к", "к", 0x43A), K("е", "е", 0x435), K("н", "н", 0x43D),
+                                      K("г", "г", 0x433), K("ш", "ш", 0x448), K("ў", "ў", 0x45E),
+                                      K("з", "з", 0x437), K("х", "х", 0x445), K("'", "'", '\'')};
+static const KeyboardKey BE_ROW2[] = {K("ф", "ф", 0x444), K("ы", "ы", 0x44B), K("в", "в", 0x432),
+                                      K("а", "а", 0x430), K("п", "п", 0x43F), K("р", "р", 0x440),
+                                      K("о", "о", 0x43E), K("л", "л", 0x43B), K("д", "д", 0x434),
+                                      K("ж", "ж", 0x436), K("э", "э", 0x44D)};
+static const KeyboardKey BE_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                      K("я", "я", 0x44F),
+                                      K("ч", "ч", 0x447),
+                                      K("с", "с", 0x441),
+                                      K("м", "м", 0x43C),
+                                      K("і", "і", 0x456),
+                                      K("т", "т", 0x442),
+                                      K("ь", "ь", 0x44C),
+                                      K("б", "б", 0x431),
+                                      K("ю", "ю", 0x44E),
+                                      KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey BE_SHIFT_ROW1[] = {K("Й", "Й", 0x419), K("Ц", "Ц", 0x426), K("У", "У", 0x423),
+                                            K("К", "К", 0x41A), K("Е", "Е", 0x415), K("Н", "Н", 0x41D),
+                                            K("Г", "Г", 0x413), K("Ш", "Ш", 0x428), K("Ў", "Ў", 0x40E),
+                                            K("З", "З", 0x417), K("Х", "Х", 0x425), K("'", "'", '\'')};
+static const KeyboardKey BE_SHIFT_ROW2[] = {K("Ф", "Ф", 0x424), K("Ы", "Ы", 0x42B), K("В", "В", 0x412),
+                                            K("А", "А", 0x410), K("П", "П", 0x41F), K("Р", "Р", 0x420),
+                                            K("О", "О", 0x41E), K("Л", "Л", 0x41B), K("Д", "Д", 0x414),
+                                            K("Ж", "Ж", 0x416), K("Э", "Э", 0x42D)};
+static const KeyboardKey BE_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                            K("Я", "Я", 0x42F),
+                                            K("Ч", "Ч", 0x427),
+                                            K("С", "С", 0x421),
+                                            K("М", "М", 0x41C),
+                                            K("І", "І", 0x406),
+                                            K("Т", "Т", 0x422),
+                                            K("Ь", "Ь", 0x42C),
+                                            K("Б", "Б", 0x411),
+                                            K("Ю", "Ю", 0x42E),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+// Kazakh ЙЦУКЕН. Kazakh adds nine letters to the Russian set, which is more
+// than a row can take on a 480px panel. The physical layout puts them over the
+// digits; here they hang off the Russian letters they are derived from, so
+// long-press reaches ә from а, ң from н and so on. That keeps the grid the same
+// width as the other Cyrillic layouts at the cost of one hold per letter.
+static const KeyboardKey KK_ROW1[] = {K("й", "й", 0x439),        K("ц", "ц", 0x446), KA("у", "у", 0x443, "ұ"),
+                                      KA("к", "к", 0x43A, "қ"),  K("е", "е", 0x435), KA("н", "н", 0x43D, "ң"),
+                                      KA("г", "г", 0x433, "ғ"),  K("ш", "ш", 0x448), K("щ", "щ", 0x449),
+                                      K("з", "з", 0x437),        KA("х", "х", 0x445, "һ"), K("ъ", "ъ", 0x44A)};
+static const KeyboardKey KK_ROW2[] = {KA("ф", "ф", 0x444, "ү"), KA("ы", "ы", 0x44B, "і"), K("в", "в", 0x432),
+                                      KA("а", "а", 0x430, "ә"), K("п", "п", 0x43F),       K("р", "р", 0x440),
+                                      KA("о", "о", 0x43E, "ө"), K("л", "л", 0x43B),       K("д", "д", 0x434),
+                                      K("ж", "ж", 0x436),       K("э", "э", 0x44D)};
+static const KeyboardKey KK_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                      K("я", "я", 0x44F),
+                                      K("ч", "ч", 0x447),
+                                      K("с", "с", 0x441),
+                                      K("м", "м", 0x43C),
+                                      K("и", "и", 0x438),
+                                      K("т", "т", 0x442),
+                                      K("ь", "ь", 0x44C),
+                                      K("б", "б", 0x431),
+                                      K("ю", "ю", 0x44E),
+                                      KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey KK_SHIFT_ROW1[] = {
+    K("Й", "Й", 0x419),       K("Ц", "Ц", 0x426),        KA("У", "У", 0x423, "Ұ"), KA("К", "К", 0x41A, "Қ"),
+    K("Е", "Е", 0x415),       KA("Н", "Н", 0x41D, "Ң"),  KA("Г", "Г", 0x413, "Ғ"), K("Ш", "Ш", 0x428),
+    K("Щ", "Щ", 0x429),       K("З", "З", 0x417),        KA("Х", "Х", 0x425, "Һ"), K("Ъ", "Ъ", 0x42A)};
+static const KeyboardKey KK_SHIFT_ROW2[] = {KA("Ф", "Ф", 0x424, "Ү"), KA("Ы", "Ы", 0x42B, "І"),
+                                            K("В", "В", 0x412),      KA("А", "А", 0x410, "Ә"),
+                                            K("П", "П", 0x41F),      K("Р", "Р", 0x420),
+                                            KA("О", "О", 0x41E, "Ө"), K("Л", "Л", 0x41B),
+                                            K("Д", "Д", 0x414),      K("Ж", "Ж", 0x416),
+                                            K("Э", "Э", 0x42D)};
+static const KeyboardKey KK_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2),
+                                            K("Я", "Я", 0x42F),
+                                            K("Ч", "Ч", 0x427),
+                                            K("С", "С", 0x421),
+                                            K("М", "М", 0x41C),
+                                            K("И", "И", 0x418),
+                                            K("Т", "Т", 0x422),
+                                            K("Ь", "Ь", 0x42C),
+                                            K("Б", "Б", 0x411),
+                                            K("Ю", "Ю", 0x42E),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+// Hebrew, standard Israeli arrangement mapped onto the QWERTY grid. Two things
+// make it simpler than the Cyrillic layouts: Hebrew has no letter case, so
+// there is one layer and no shift key, and its letters have no contextual
+// forms, so no shaping is needed at the table level.
+//
+// Five letters have a final form used at the end of a word. Four of them get
+// their own key, as on a physical Israeli keyboard (ן ם ך ץ). The fifth, ף,
+// does not fit the grid and long-presses off פ instead — the same
+// base-letter-holds-its-variant idea used for ё in Russian and ґ in Ukrainian.
+//
+// Right-to-left is handled downstream: the renderer bidi-reorders the text it
+// draws, so the keyboard only has to insert code points in logical order.
+static const KeyboardKey HE_ROW1[] = {K("/", "/", '/'),   K("'", "'", '\''), K("ק", "ק", 0x5E7),
+                                      K("ר", "ר", 0x5E8), K("א", "א", 0x5D0),  K("ט", "ט", 0x5D8),
+                                      K("ו", "ו", 0x5D5), K("ן", "ן", 0x5DF),  K("ם", "ם", 0x5DD),
+                                      KA("פ", "פ", 0x5E4, "ף")};
+static const KeyboardKey HE_ROW2[] = {K("ש", "ש", 0x5E9), K("ד", "ד", 0x5D3), K("ג", "ג", 0x5D2),
+                                      K("כ", "כ", 0x5DB), K("ע", "ע", 0x5E2), K("י", "י", 0x5D9),
+                                      K("ח", "ח", 0x5D7), K("ל", "ל", 0x5DC), K("ך", "ך", 0x5DA)};
+static const KeyboardKey HE_ROW3[] = {K("ז", "ז", 0x5D6), K("ס", "ס", 0x5E1),
+                                      K("ב", "ב", 0x5D1), K("ה", "ה", 0x5D4),
+                                      K("נ", "נ", 0x5E0), K("מ", "מ", 0x5DE),
+                                      K("צ", "צ", 0x5E6), K("ת", "ת", 0x5EA),
+                                      K("ץ", "ץ", 0x5E5),
+                                      KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
 // Bottom row carrying the script-switch key. Kept separate from EN_ROW4 so a
 // single-script build renders exactly as before — the key costs a slot in the
 // row, and there is no point spending it when there is nowhere to switch to.
@@ -346,6 +507,66 @@ static const KeyboardRow RU_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
                                                 {RU_SHIFT_ROW3, 11, 0},
                                                 {LANG_ROW4, 4, 0}};
 
+static const KeyboardRow UK_ROWS[] = {
+    {UK_ROW1, 12, 0}, {UK_ROW2, 11, 0}, {UK_ROW3, 11, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow UK_SHIFT_ROWS[] = {{UK_SHIFT_ROW1, 12, 0},
+                                            {UK_SHIFT_ROW2, 11, 0},
+                                            {UK_SHIFT_ROW3, 11, 0},
+                                            {LANG_ROW4, 4, 0}};
+static const KeyboardRow UK_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                          {UK_ROW1, 12, 0},
+                                          {UK_ROW2, 11, 0},
+                                          {UK_ROW3, 11, 0},
+                                          {LANG_ROW4, 4, 0}};
+static const KeyboardRow UK_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
+                                                {UK_SHIFT_ROW1, 12, 0},
+                                                {UK_SHIFT_ROW2, 11, 0},
+                                                {UK_SHIFT_ROW3, 11, 0},
+                                                {LANG_ROW4, 4, 0}};
+
+static const KeyboardRow BE_ROWS[] = {
+    {BE_ROW1, 12, 0}, {BE_ROW2, 11, 0}, {BE_ROW3, 11, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow BE_SHIFT_ROWS[] = {{BE_SHIFT_ROW1, 12, 0},
+                                            {BE_SHIFT_ROW2, 11, 0},
+                                            {BE_SHIFT_ROW3, 11, 0},
+                                            {LANG_ROW4, 4, 0}};
+static const KeyboardRow BE_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                          {BE_ROW1, 12, 0},
+                                          {BE_ROW2, 11, 0},
+                                          {BE_ROW3, 11, 0},
+                                          {LANG_ROW4, 4, 0}};
+static const KeyboardRow BE_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
+                                                {BE_SHIFT_ROW1, 12, 0},
+                                                {BE_SHIFT_ROW2, 11, 0},
+                                                {BE_SHIFT_ROW3, 11, 0},
+                                                {LANG_ROW4, 4, 0}};
+
+static const KeyboardRow KK_ROWS[] = {
+    {KK_ROW1, 12, 0}, {KK_ROW2, 11, 0}, {KK_ROW3, 11, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow KK_SHIFT_ROWS[] = {{KK_SHIFT_ROW1, 12, 0},
+                                            {KK_SHIFT_ROW2, 11, 0},
+                                            {KK_SHIFT_ROW3, 11, 0},
+                                            {LANG_ROW4, 4, 0}};
+static const KeyboardRow KK_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                          {KK_ROW1, 12, 0},
+                                          {KK_ROW2, 11, 0},
+                                          {KK_ROW3, 11, 0},
+                                          {LANG_ROW4, 4, 0}};
+static const KeyboardRow KK_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0},
+                                                {KK_SHIFT_ROW1, 12, 0},
+                                                {KK_SHIFT_ROW2, 11, 0},
+                                                {KK_SHIFT_ROW3, 11, 0},
+                                                {LANG_ROW4, 4, 0}};
+
+static const KeyboardRow HE_ROWS[] = {
+    {HE_ROW1, 10, 0}, {HE_ROW2, 9, 1}, {HE_ROW3, 10, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow HE_NUM_ROWS[] = {{NUM_ROW, 10, 0},
+                                          {HE_ROW1, 10, 0},
+                                          {HE_ROW2, 9, 1},
+                                          {HE_ROW3, 10, 0},
+                                          {LANG_ROW4, 4, 0}};
+
+
 // Latin layers wearing the lang-key bottom row, so a multi-script keyboard can
 // switch back. Letter rows are the plain EN tables — same QWERTY, no copies.
 static const KeyboardRow EN_LANG_ROWS[] = {{EN_ROW1, 10, 0}, {EN_ROW2, 9, 1}, {EN_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
@@ -368,6 +589,20 @@ static const KeyboardLayout RU_LAYOUT{RU_ROWS, 4};
 static const KeyboardLayout RU_SHIFT_LAYOUT{RU_SHIFT_ROWS, 4};
 static const KeyboardLayout RU_NUM_LAYOUT{RU_NUM_ROWS, 5};
 static const KeyboardLayout RU_SHIFT_NUM_LAYOUT{RU_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout UK_LAYOUT{UK_ROWS, 4};
+static const KeyboardLayout UK_SHIFT_LAYOUT{UK_SHIFT_ROWS, 4};
+static const KeyboardLayout UK_NUM_LAYOUT{UK_NUM_ROWS, 5};
+static const KeyboardLayout UK_SHIFT_NUM_LAYOUT{UK_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout BE_LAYOUT{BE_ROWS, 4};
+static const KeyboardLayout BE_SHIFT_LAYOUT{BE_SHIFT_ROWS, 4};
+static const KeyboardLayout BE_NUM_LAYOUT{BE_NUM_ROWS, 5};
+static const KeyboardLayout BE_SHIFT_NUM_LAYOUT{BE_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout KK_LAYOUT{KK_ROWS, 4};
+static const KeyboardLayout KK_SHIFT_LAYOUT{KK_SHIFT_ROWS, 4};
+static const KeyboardLayout KK_NUM_LAYOUT{KK_NUM_ROWS, 5};
+static const KeyboardLayout KK_SHIFT_NUM_LAYOUT{KK_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout HE_LAYOUT{HE_ROWS, 4};
+static const KeyboardLayout HE_NUM_LAYOUT{HE_NUM_ROWS, 5};
 static const KeyboardLayout EN_LANG_LAYOUT{EN_LANG_ROWS, 4};
 static const KeyboardLayout EN_SHIFT_LANG_LAYOUT{EN_SHIFT_LANG_ROWS, 4};
 static const KeyboardLayout EN_LANG_NUM_LAYOUT{EN_LANG_NUM_ROWS, 5};
@@ -393,6 +628,20 @@ const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted, b
     if (shifted) return numberRow ? RU_SHIFT_NUM_LAYOUT : RU_SHIFT_LAYOUT;
     return numberRow ? RU_NUM_LAYOUT : RU_LAYOUT;
   }
+  if (id == KeyboardLayoutId::CyrillicUk) {
+    if (shifted) return numberRow ? UK_SHIFT_NUM_LAYOUT : UK_SHIFT_LAYOUT;
+    return numberRow ? UK_NUM_LAYOUT : UK_LAYOUT;
+  }
+  if (id == KeyboardLayoutId::CyrillicBe) {
+    if (shifted) return numberRow ? BE_SHIFT_NUM_LAYOUT : BE_SHIFT_LAYOUT;
+    return numberRow ? BE_NUM_LAYOUT : BE_LAYOUT;
+  }
+  if (id == KeyboardLayoutId::CyrillicKk) {
+    if (shifted) return numberRow ? KK_SHIFT_NUM_LAYOUT : KK_SHIFT_LAYOUT;
+    return numberRow ? KK_NUM_LAYOUT : KK_LAYOUT;
+  }
+  // Hebrew has no case, so shift is ignored -- there is only one letter layer.
+  if (id == KeyboardLayoutId::HebrewIl) return numberRow ? HE_NUM_LAYOUT : HE_LAYOUT;
   if (id == KeyboardLayoutId::QwertyEn && langKey) {
     if (shifted) return numberRow ? EN_SHIFT_LANG_NUM_LAYOUT : EN_SHIFT_LANG_LAYOUT;
     return numberRow ? EN_LANG_NUM_LAYOUT : EN_LANG_LAYOUT;

--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -567,6 +567,13 @@ static const KeyboardRow HE_NUM_ROWS[] = {{NUM_ROW, 10, 0},
                                           {LANG_ROW4, 4, 0}};
 
 
+static const KeyboardRow FR_LANG_ROWS[] = {{FR_ROW1, 10, 0}, {FR_ROW2, 10, 0}, {FR_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow FR_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0}, {FR_ROW1, 10, 0}, {FR_ROW2, 10, 0}, {FR_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow DE_LANG_ROWS[] = {{DE_ROW1, 10, 0}, {DE_ROW2, 10, 0}, {DE_ROW3, 10, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow DE_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0}, {DE_ROW1, 10, 0}, {DE_ROW2, 10, 0}, {DE_ROW3, 10, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow ES_LANG_ROWS[] = {{ES_ROW1, 10, 0}, {ES_ROW2, 10, 0}, {ES_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow ES_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0}, {ES_ROW1, 10, 0}, {ES_ROW2, 10, 0}, {ES_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+
 // Latin layers wearing the lang-key bottom row, so a multi-script keyboard can
 // switch back. Letter rows are the plain EN tables — same QWERTY, no copies.
 static const KeyboardRow EN_LANG_ROWS[] = {{EN_ROW1, 10, 0}, {EN_ROW2, 9, 1}, {EN_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
@@ -603,6 +610,12 @@ static const KeyboardLayout KK_NUM_LAYOUT{KK_NUM_ROWS, 5};
 static const KeyboardLayout KK_SHIFT_NUM_LAYOUT{KK_SHIFT_NUM_ROWS, 5};
 static const KeyboardLayout HE_LAYOUT{HE_ROWS, 4};
 static const KeyboardLayout HE_NUM_LAYOUT{HE_NUM_ROWS, 5};
+static const KeyboardLayout FR_LANG_LAYOUT{FR_LANG_ROWS, 4};
+static const KeyboardLayout FR_LANG_NUM_LAYOUT{FR_LANG_NUM_ROWS, 5};
+static const KeyboardLayout DE_LANG_LAYOUT{DE_LANG_ROWS, 4};
+static const KeyboardLayout DE_LANG_NUM_LAYOUT{DE_LANG_NUM_ROWS, 5};
+static const KeyboardLayout ES_LANG_LAYOUT{ES_LANG_ROWS, 4};
+static const KeyboardLayout ES_LANG_NUM_LAYOUT{ES_LANG_NUM_ROWS, 5};
 static const KeyboardLayout EN_LANG_LAYOUT{EN_LANG_ROWS, 4};
 static const KeyboardLayout EN_SHIFT_LANG_LAYOUT{EN_SHIFT_LANG_ROWS, 4};
 static const KeyboardLayout EN_LANG_NUM_LAYOUT{EN_LANG_NUM_ROWS, 5};
@@ -649,10 +662,13 @@ const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted, b
   if (shifted && id == KeyboardLayoutId::QwertyEn) return numberRow ? EN_SHIFT_NUM_LAYOUT : EN_SHIFT_LAYOUT;
   switch (id) {
     case KeyboardLayoutId::AzertyFr:
+      if (langKey) return numberRow ? FR_LANG_NUM_LAYOUT : FR_LANG_LAYOUT;
       return numberRow ? FR_NUM_LAYOUT : FR_LAYOUT;
     case KeyboardLayoutId::QwertzDe:
+      if (langKey) return numberRow ? DE_LANG_NUM_LAYOUT : DE_LANG_LAYOUT;
       return numberRow ? DE_NUM_LAYOUT : DE_LAYOUT;
     case KeyboardLayoutId::SpanishEs:
+      if (langKey) return numberRow ? ES_LANG_NUM_LAYOUT : ES_LANG_LAYOUT;
       return numberRow ? ES_NUM_LAYOUT : ES_LAYOUT;
     case KeyboardLayoutId::QwertyEn:
     default:

--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -279,6 +279,49 @@ static const KeyboardKey RU_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_K
                                             K("Ю", "Ю", 0x42E),
                                             KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
 
+
+// Uppercase layers for the Latin locale layouts. Their letter keys report ASCII
+// ids, so long-press already reached the opposite case through the implicit
+// flip; what was missing is the shift key doing anything, even though the
+// tables have always drawn one.
+//
+// The locale letters keep dedicated ids in the shifted layer (É/Ü/Ñ) because
+// keyboardOutputFor resolves ids within a layout and the lowercase ids are
+// taken. ß has no uppercase in this font (U+1E9E is absent) and German
+// capitalises it as SS anyway, so it stays as it is.
+static const KeyboardKey FR_SHIFT_ROW1[] = {K("A", "A", 'A'), K("Z", "Z", 'Z'), K("E", "E", 'E'), K("R", "R", 'R'),
+                                            K("T", "T", 'T'), K("Y", "Y", 'Y'), K("U", "U", 'U'), K("I", "I", 'I'),
+                                            K("O", "O", 'O'), K("P", "P", 'P')};
+static const KeyboardKey FR_SHIFT_ROW2[] = {K("Q", "Q", 'Q'), K("S", "S", 'S'), K("D", "D", 'D'), K("F", "F", 'F'),
+                                            K("G", "G", 'G'), K("H", "H", 'H'), K("J", "J", 'J'), K("K", "K", 'K'),
+                                            K("L", "L", 'L'), K("M", "M", 'M')};
+static const KeyboardKey FR_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2), K("W", "W", 'W'),
+                                            K("X", "X", 'X'), K("C", "C", 'C'), K("V", "V", 'V'), K("B", "B", 'B'),
+                                            K("N", "N", 'N'), K("É", "É", 1051),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey DE_SHIFT_ROW1[] = {K("Q", "Q", 'Q'), K("W", "W", 'W'), K("E", "E", 'E'), K("R", "R", 'R'),
+                                            K("T", "T", 'T'), K("Z", "Z", 'Z'), K("U", "U", 'U'), K("I", "I", 'I'),
+                                            K("O", "O", 'O'), K("P", "P", 'P')};
+static const KeyboardKey DE_SHIFT_ROW2[] = {K("A", "A", 'A'), K("S", "S", 'S'), K("D", "D", 'D'), K("F", "F", 'F'),
+                                            K("G", "G", 'G'), K("H", "H", 'H'), K("J", "J", 'J'), K("K", "K", 'K'),
+                                            K("L", "L", 'L'), K("Ü", "Ü", 1151)};
+static const KeyboardKey DE_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2), K("Y", "Y", 'Y'),
+                                            K("X", "X", 'X'), K("C", "C", 'C'), K("V", "V", 'V'), K("B", "B", 'B'),
+                                            K("N", "N", 'N'), K("M", "M", 'M'), K("ß", "ß", 1102),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
+static const KeyboardKey ES_SHIFT_ROW1[] = {K("Q", "Q", 'Q'), K("W", "W", 'W'), K("E", "E", 'E'), K("R", "R", 'R'),
+                                            K("T", "T", 'T'), K("Y", "Y", 'Y'), K("U", "U", 'U'), K("I", "I", 'I'),
+                                            K("O", "O", 'O'), K("P", "P", 'P')};
+static const KeyboardKey ES_SHIFT_ROW2[] = {K("A", "A", 'A'), K("S", "S", 'S'), K("D", "D", 'D'), K("F", "F", 'F'),
+                                            K("G", "G", 'G'), K("H", "H", 'H'), K("J", "J", 'J'), K("K", "K", 'K'),
+                                            K("L", "L", 'L'), K("Ñ", "Ñ", 1251)};
+static const KeyboardKey ES_SHIFT_ROW3[] = {KS("Shift", KeyKind::Shift, QWERTY_KEY_SHIFT, 2), K("Z", "Z", 'Z'),
+                                            K("X", "X", 'X'), K("C", "C", 'C'), K("V", "V", 'V'), K("B", "B", 'B'),
+                                            K("N", "N", 'N'), K("M", "M", 'M'),
+                                            KS("Del", KeyKind::Delete, QWERTY_KEY_BACKSPACE, 2)};
+
 // Ukrainian ЙЦУКЕН. Differs from Russian in four slots: ї replaces ъ, і
 // replaces ы, є replaces э, and и is the Ukrainian и (U+0438) as in Russian
 // while й stays put. ґ has no key of its own — it long-presses off г, the
@@ -574,6 +617,19 @@ static const KeyboardRow DE_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0}, {DE_ROW1, 10, 0
 static const KeyboardRow ES_LANG_ROWS[] = {{ES_ROW1, 10, 0}, {ES_ROW2, 10, 0}, {ES_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
 static const KeyboardRow ES_LANG_NUM_ROWS[] = {{NUM_ROW, 10, 0}, {ES_ROW1, 10, 0}, {ES_ROW2, 10, 0}, {ES_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
 
+static const KeyboardRow FR_SHIFT_ROWS[] = {{FR_SHIFT_ROW1, 10, 0}, {FR_SHIFT_ROW2, 10, 0}, {FR_SHIFT_ROW3, 9, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow FR_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {FR_SHIFT_ROW1, 10, 0}, {FR_SHIFT_ROW2, 10, 0}, {FR_SHIFT_ROW3, 9, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow FR_SHIFT_LANG_ROWS[] = {{FR_SHIFT_ROW1, 10, 0}, {FR_SHIFT_ROW2, 10, 0}, {FR_SHIFT_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow FR_SHIFT_LANG_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {FR_SHIFT_ROW1, 10, 0}, {FR_SHIFT_ROW2, 10, 0}, {FR_SHIFT_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow DE_SHIFT_ROWS[] = {{DE_SHIFT_ROW1, 10, 0}, {DE_SHIFT_ROW2, 10, 0}, {DE_SHIFT_ROW3, 10, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow DE_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {DE_SHIFT_ROW1, 10, 0}, {DE_SHIFT_ROW2, 10, 0}, {DE_SHIFT_ROW3, 10, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow DE_SHIFT_LANG_ROWS[] = {{DE_SHIFT_ROW1, 10, 0}, {DE_SHIFT_ROW2, 10, 0}, {DE_SHIFT_ROW3, 10, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow DE_SHIFT_LANG_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {DE_SHIFT_ROW1, 10, 0}, {DE_SHIFT_ROW2, 10, 0}, {DE_SHIFT_ROW3, 10, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow ES_SHIFT_ROWS[] = {{ES_SHIFT_ROW1, 10, 0}, {ES_SHIFT_ROW2, 10, 0}, {ES_SHIFT_ROW3, 9, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow ES_SHIFT_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {ES_SHIFT_ROW1, 10, 0}, {ES_SHIFT_ROW2, 10, 0}, {ES_SHIFT_ROW3, 9, 0}, {EN_ROW4, 3, 0}};
+static const KeyboardRow ES_SHIFT_LANG_ROWS[] = {{ES_SHIFT_ROW1, 10, 0}, {ES_SHIFT_ROW2, 10, 0}, {ES_SHIFT_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+static const KeyboardRow ES_SHIFT_LANG_NUM_ROWS[] = {{NUM_SHIFT_ROW, 10, 0}, {ES_SHIFT_ROW1, 10, 0}, {ES_SHIFT_ROW2, 10, 0}, {ES_SHIFT_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
+
 // Latin layers wearing the lang-key bottom row, so a multi-script keyboard can
 // switch back. Letter rows are the plain EN tables — same QWERTY, no copies.
 static const KeyboardRow EN_LANG_ROWS[] = {{EN_ROW1, 10, 0}, {EN_ROW2, 9, 1}, {EN_ROW3, 9, 0}, {LANG_ROW4, 4, 0}};
@@ -616,6 +672,18 @@ static const KeyboardLayout DE_LANG_LAYOUT{DE_LANG_ROWS, 4};
 static const KeyboardLayout DE_LANG_NUM_LAYOUT{DE_LANG_NUM_ROWS, 5};
 static const KeyboardLayout ES_LANG_LAYOUT{ES_LANG_ROWS, 4};
 static const KeyboardLayout ES_LANG_NUM_LAYOUT{ES_LANG_NUM_ROWS, 5};
+static const KeyboardLayout FR_SHIFT_LAYOUT{FR_SHIFT_ROWS, 4};
+static const KeyboardLayout FR_SHIFT_NUM_LAYOUT{FR_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout FR_SHIFT_LANG_LAYOUT{FR_SHIFT_LANG_ROWS, 4};
+static const KeyboardLayout FR_SHIFT_LANG_NUM_LAYOUT{FR_SHIFT_LANG_NUM_ROWS, 5};
+static const KeyboardLayout DE_SHIFT_LAYOUT{DE_SHIFT_ROWS, 4};
+static const KeyboardLayout DE_SHIFT_NUM_LAYOUT{DE_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout DE_SHIFT_LANG_LAYOUT{DE_SHIFT_LANG_ROWS, 4};
+static const KeyboardLayout DE_SHIFT_LANG_NUM_LAYOUT{DE_SHIFT_LANG_NUM_ROWS, 5};
+static const KeyboardLayout ES_SHIFT_LAYOUT{ES_SHIFT_ROWS, 4};
+static const KeyboardLayout ES_SHIFT_NUM_LAYOUT{ES_SHIFT_NUM_ROWS, 5};
+static const KeyboardLayout ES_SHIFT_LANG_LAYOUT{ES_SHIFT_LANG_ROWS, 4};
+static const KeyboardLayout ES_SHIFT_LANG_NUM_LAYOUT{ES_SHIFT_LANG_NUM_ROWS, 5};
 static const KeyboardLayout EN_LANG_LAYOUT{EN_LANG_ROWS, 4};
 static const KeyboardLayout EN_SHIFT_LANG_LAYOUT{EN_SHIFT_LANG_ROWS, 4};
 static const KeyboardLayout EN_LANG_NUM_LAYOUT{EN_LANG_NUM_ROWS, 5};
@@ -662,12 +730,18 @@ const KeyboardLayout& builtinKeyboardLayout(KeyboardLayoutId id, bool shifted, b
   if (shifted && id == KeyboardLayoutId::QwertyEn) return numberRow ? EN_SHIFT_NUM_LAYOUT : EN_SHIFT_LAYOUT;
   switch (id) {
     case KeyboardLayoutId::AzertyFr:
+      if (shifted && langKey) return numberRow ? FR_SHIFT_LANG_NUM_LAYOUT : FR_SHIFT_LANG_LAYOUT;
+      if (shifted) return numberRow ? FR_SHIFT_NUM_LAYOUT : FR_SHIFT_LAYOUT;
       if (langKey) return numberRow ? FR_LANG_NUM_LAYOUT : FR_LANG_LAYOUT;
       return numberRow ? FR_NUM_LAYOUT : FR_LAYOUT;
     case KeyboardLayoutId::QwertzDe:
+      if (shifted && langKey) return numberRow ? DE_SHIFT_LANG_NUM_LAYOUT : DE_SHIFT_LANG_LAYOUT;
+      if (shifted) return numberRow ? DE_SHIFT_NUM_LAYOUT : DE_SHIFT_LAYOUT;
       if (langKey) return numberRow ? DE_LANG_NUM_LAYOUT : DE_LANG_LAYOUT;
       return numberRow ? DE_NUM_LAYOUT : DE_LAYOUT;
     case KeyboardLayoutId::SpanishEs:
+      if (shifted && langKey) return numberRow ? ES_SHIFT_LANG_NUM_LAYOUT : ES_SHIFT_LANG_LAYOUT;
+      if (shifted) return numberRow ? ES_SHIFT_NUM_LAYOUT : ES_SHIFT_LAYOUT;
       if (langKey) return numberRow ? ES_LANG_NUM_LAYOUT : ES_LANG_LAYOUT;
       return numberRow ? ES_NUM_LAYOUT : ES_LAYOUT;
     case KeyboardLayoutId::QwertyEn:


### PR DESCRIPTION
Adds five keyboard layouts and the machinery for reaching more than one script from one keyboard.

Written after the discussion on [crosspoint-reader#2828](https://github.com/crosspoint-reader/crosspoint-reader/pull/2828), where @Uri-Tauber asked for layouts to live here rather than in the firmware, and for language switching to be general rather than one language paired with English. The firmware side is a companion PR against crosspoint-reader; this half stands on its own and changes nothing for existing single-script keyboards.

## New layouts

| Id | Notes |
|---|---|
| `CyrillicRu` | ЙЦУКЕН |
| `CyrillicUk` | ї/і/є in place of ъ/ы/э; ґ long-presses off г |
| `CyrillicBe` | ў and і; apostrophe where ъ sits |
| `CyrillicKk` | nine extra letters long-press off the ones they derive from |
| `HebrewIl` | single layer, no shift key |

The Cyrillic four share Russian's geometry and differ in a handful of slots. Their rows run 12/11/11 against Latin's 10/9/9, so a caller sizing a hit-test buffer from the widest layout has to account for that — the firmware PR bumps its `InteractionBuffer` from 48 to 56.

Kazakh's nine additions and Ukrainian's ґ have no room on a 480px grid, so they hang off the letters they derive from and are reached by long-press. Hebrew's fifth final form (ף) does the same off פ; the other four have their own keys as on a physical Israeli keyboard.

## Script switching

`KeyKind::Lang` is a new key kind, deliberately distinct from `Mode`: `Mode` pages between letters and symbols within one script, `Lang` moves between scripts. `QWERTY_KEY_LANG` is `-4` — `-3` is already taken by an app-defined key downstream.

Its label always comes from the app through `KeyboardProps::langLabel`, following the pattern already used for `okLabel` / `shiftLabel` / `modeLabel`: which layout is active is app state, and a static table cannot know it.

The key is opt-in through `builtinKeyboardLayout`'s new `langKey` flag. It costs a slot in the bottom row, so a single-script keyboard renders exactly as before. The non-Latin layouts ignore the flag and always carry the key — a keyboard with no Latin letters cannot type a Wi-Fi password or a URL, so there always has to be a way back.

## Two fixes to existing layouts

**`AzertyFr`, `QwertzDe` and `SpanishEs` drew a Shift key that did nothing.** They were declared single-layer, so `shifted` was ignored, while their tables have always rendered the key. Pressing it highlighted the key and changed no letters. Each now has an uppercase layer.

The locale letters keep dedicated ids in the shifted layer (É/Ü/Ñ) because `keyboardOutputFor` resolves ids within one layout and the lowercase ids are taken. ß stays lowercase under shift: the bundled fonts have no U+1E9E, and German capitalises it as SS anyway.

**`keyboardAltOutputFor` now case-flips Cyrillic** as it already did ASCII — А-Я and а-я share the same 0x20 offset, with Ё/ё handled separately. Without it every Cyrillic key would need an explicit `alt`, which the renderer then draws as a corner hint, putting "йЙ" on each key. Its static buffer grows 2 → 3 bytes because Cyrillic is two bytes in UTF-8.

## Notes for review

Cyrillic key ids are the letters' code points. They overlap the localized Latin ids numerically — э is 0x44D, which is 1101, the same number as `QwertzDe`'s ü. That is safe because ids only ever resolve within one layout, which is why `keyboardOutputFor` takes the layout as its first argument, and two scripts are never on screen at once. Anything mapping an id to a character without knowing the layout would break.

Arabic is deliberately absent. The bundled fonts carry Arabic presentation forms but not the base letters, while translations store base letters — so a shaper sits between the two, and which side of it a key label lands on decides whether the tables need one column or two. That needs an experiment rather than a guess.

## Testing

Built and exercised in the desktop simulator across all nine layouts: switching in and out of each, shift on each, long-press alternates, the number row and symbol layers. The consuming firmware's host test suite passes (129/129).

Checked by script over the tables: no duplicate key ids within a layer, every row's declared `count` matches its actual key count, every layout reachable with `langKey` set carries the key in every variant, and upper/lower layers correspond one-to-one.

Not tested on hardware.
