### PR TITLE
fix(x3): one forced full sync after begin(), not two

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.cpp
@@ -144,7 +144,15 @@ void Uc8253X3Driver::initController(EpdBus& bus) {
 void Uc8253X3Driver::begin(EpdBus& bus) {
   bus.reset(50);  // X3 needs an extra settle after reset
   _redRamSynced = false;
-  _initialFullSyncsRemaining = 2;
+  // One forced clean after begin(), matching the UC8279/SSD1677 siblings' one-shot
+  // _needFullClear. This was 2, which made the paint AFTER the first one a full sync too,
+  // whatever mode it asked for (see the doFullSync condition in displayStart). On a
+  // consumer that boots into a splash that is measurable: the splash consumed sync #1 and
+  // the first real screen still paid sync #2, so a FAST refresh that costs 435 ms once
+  // warm cost 2989 ms — the X4 running the identical boot paid 526 ms for the same paint.
+  // The remaining sync still clears whatever the panel physically held (the sleep screen),
+  // which is what the initial forced clean is for.
+  _initialFullSyncsRemaining = 1;
   _forceFullSyncNext = false;
   _forcedConditionPassesNext = 0;
   _inGrayscaleMode = false;


### PR DESCRIPTION
## Problem

`Uc8253X3Driver::begin()` resets `_initialFullSyncsRemaining` to **2**. Because `displayStart()`'s `doFullSync` condition includes `_initialFullSyncsRemaining > 0`, this promotes the paint *after* the first one to a full sync as well, whatever mode it actually asked for.

The UC8279 and SSD1677 siblings use a one-shot `_needFullClear` for the same job. This brings the X3 in line with them.

## Impact

On a consumer that boots into a splash screen, the splash consumes sync #1 and the first real screen still pays sync #2. Measured on Xteink X3 hardware:

| | before | after |
|---|---|---|
| splash (HALF, 3 DRF passes) | 2303 ms | 2303 ms (unchanged) |
| first home screen (FAST) | **2989 ms** | **436 ms** |
| press → home on screen | 7634 ms | 4569 ms |

For reference, an X4 running the identical firmware and boot path pays 527 ms for that same home-screen paint — the X3 was 2.5 s behind purely because of this.

Subsequent paints measured 437 ms and 436 ms, so no promoted sync creeps back in.

## Why this is still correct

The remaining sync clears whatever the panel physically held (the sleep screen), which is what the initial forced clean exists for. The condition pass that used to land on the second sync now lands on the single one, through the existing `else if (_initialFullSyncsRemaining == 1)` branch in `displayStart()` — so that branch does not become dead code, and the one clean still gets its settle pass on both the forced (`requestResync`) and unforced paths.

## Validation

Device-tested on X3: splash and home screen are visually clean, no ghosting of the previous frame. Also regression-checked on X4 (unaffected — different driver, already one-shot).