### PR TITLE
feat: add Murphy M4 hardware support

### DIFF
--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -16,7 +16,7 @@
 // selectDevice); ACTIVE defaults to a compile-time default until then.
 
 #include <Arduino.h>
-#include <driver/gpio.h>   // gpio_hold_dis in releaseSdRail()
+#include <driver/gpio.h>  // gpio_hold_dis in releaseSdRail()
 #include <esp_rom_sys.h>  // esp_rom_printf in holdPowerRails()
 
 // ============================================================================
@@ -63,13 +63,16 @@
 #ifndef FREEINK_DEVICE_PAPERS3
 #define FREEINK_DEVICE_PAPERS3 0
 #endif
+#ifndef FREEINK_DEVICE_MURPHY_M4
+#define FREEINK_DEVICE_MURPHY_M4 0
+#endif
 
 // --- 2) Coherence: exactly one MCU family, at least one device ---------------
 #if !(FREEINK_DEVICE_X4 || FREEINK_DEVICE_X3 || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_M5 || FREEINK_DEVICE_MURPHY || \
       FREEINK_DEVICE_DELINK || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_M5PAPER || FREEINK_DEVICE_STICKY ||            \
-      FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3)
+      FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_MURPHY_M4)
 #error \
-    "FreeInk: no device selected. Pass at least one -DFREEINK_DEVICE_<NAME> (X4, X3, X4PRO, M5, MURPHY, DELINK, LILYGO, M5PAPER, STICKY, PAPERMONO, PAPERS3) in your build env — see platformio.sample.ini."
+    "FreeInk: no device selected. Pass at least one -DFREEINK_DEVICE_<NAME> (X4, X3, X4PRO, M5, MURPHY, DELINK, LILYGO, M5PAPER, STICKY, PAPERMONO, PAPERS3, MURPHY_M4) in your build env — see platformio.sample.ini."
 #endif
 // Each device belongs to one MCU family; a binary targets exactly one. X3/X4 are
 // ESP32-C3; M5 PaperColor/Murphy/de-link/LilyGo are ESP32-S3; M5Paper v1.1 is the
@@ -78,7 +81,8 @@
 #define FREEINK_MCU_C3 (FREEINK_DEVICE_X3 || FREEINK_DEVICE_X4)
 #define FREEINK_MCU_S3                                                                                    \
   (FREEINK_DEVICE_M5 || FREEINK_DEVICE_MURPHY || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_LILYGO ||        \
-   FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3)
+   FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 ||  \
+   FREEINK_DEVICE_MURPHY_M4)
 #define FREEINK_MCU_ESP32 (FREEINK_DEVICE_M5PAPER)
 #if (FREEINK_MCU_C3 + FREEINK_MCU_S3 + FREEINK_MCU_ESP32) != 1
 #error \
@@ -92,7 +96,8 @@
 // X4 Pro is a distinct ESP32-S3 device (NOT the C3 X4): its 800x480 panel may
 // use SSD1677, UC8179, or UC8279, recovered from OEM firmware and hardware
 // references — see docs/xteink-x4pro-support.md.
-#if FREEINK_DEVICE_X4 || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO
+#if FREEINK_DEVICE_X4 || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || \
+    FREEINK_DEVICE_MURPHY_M4
 #define FREEINK_DRIVER_SSD1677 1
 #else
 #define FREEINK_DRIVER_SSD1677 0
@@ -168,14 +173,14 @@
 
 // --- 4) Derive default capabilities (override with -DFREEINK_CAP_*=0/1) -------
 #ifndef FREEINK_CAP_TOUCH
-#define FREEINK_CAP_TOUCH                                                                         \
+#define FREEINK_CAP_TOUCH                                                                               \
   (FREEINK_DEVICE_MURPHY || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_M5PAPER || FREEINK_DEVICE_STICKY || \
-   FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3)
+   FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_MURPHY_M4)
 #endif
 #ifndef FREEINK_CAP_FRONTLIGHT
-#define FREEINK_CAP_FRONTLIGHT                                                                     \
+#define FREEINK_CAP_FRONTLIGHT                                                                        \
   (FREEINK_DEVICE_DELINK || FREEINK_DEVICE_MURPHY || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_X4PRO || \
-   FREEINK_DEVICE_PAPERMONO)
+   FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_MURPHY_M4)
 #endif
 // Warm/cool color-temperature frontlight: a second warm PWM channel on top of
 // the brightness one (FrontlightConfig::gpioWarm). Sub-capability of
@@ -183,7 +188,7 @@
 // builds (Paper Mono, de-link, Murphy, LilyGo). Within a multi-device build
 // the profile's gpioWarm stays the runtime truth (hasColorTemperature()).
 #ifndef FREEINK_CAP_WARMLIGHT
-#define FREEINK_CAP_WARMLIGHT (FREEINK_DEVICE_X4PRO)
+#define FREEINK_CAP_WARMLIGHT (FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_MURPHY_M4)
 #endif
 // USB Mass Storage ("USB Transfer" mode): exposes the SD card to a host over
 // USB-MSC. OPT-IN (default off), NOT board-derived: it forces the build into
@@ -296,7 +301,8 @@
 // must define USE_BLOCK_DEVICE_INTERFACE=1 for the SdFat FsVolume these mount on.
 // Override with -DFREEINK_SD_SDMMC=0/1.
 #ifndef FREEINK_SD_SDMMC
-#define FREEINK_SD_SDMMC (FREEINK_DEVICE_DELINK || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO)
+#define FREEINK_SD_SDMMC \
+  (FREEINK_DEVICE_DELINK || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_MURPHY_M4)
 #endif
 
 // Serial log transport hint for consumer firmware. Boards can share the same MCU
@@ -339,9 +345,10 @@ enum class Board : uint8_t {
   XteinkX4,
   XteinkX3,
   XteinkX3Uc8279,  // newer X3 production run: same board/glass, UC8279d controller
-  XteinkX4Pro,  // ESP32-S3 sibling of the C3 X4: SSD1677 + GT911 touch + warm/cold frontlight
+  XteinkX4Pro,     // ESP32-S3 sibling of the C3 X4: SSD1677 + GT911 touch + warm/cold frontlight
   M5StackPaperColor,
   MurphyM3,
+  MurphyM4,
   DeLink,
   LilyGoT5S3,
   M5PaperV11,
@@ -352,12 +359,12 @@ enum class Board : uint8_t {
 
 // How the board reports button presses.
 enum class InputStyle : uint8_t {
-  XteinkAdcLadder,         // resistor ladder on two ADC pins (X3/X4)
-  DigitalButtons,          // plain active-low GPIO buttons
-  DigitalConfirmBackHold,  // confirm held > N ms synthesizes BACK (M5 PaperColor)
-  DigitalConfirmPowerHold, // confirm click, power hold on a shared GPIO
-  DigitalFiveKey,          // 3 physical GPIO keys + synthesized events (Murphy M3)
-  DigitalTwoButton,        // short up/down; holds synthesize back/confirm/power
+  XteinkAdcLadder,          // resistor ladder on two ADC pins (X3/X4)
+  DigitalButtons,           // plain active-low GPIO buttons
+  DigitalConfirmBackHold,   // confirm held > N ms synthesizes BACK (M5 PaperColor)
+  DigitalConfirmPowerHold,  // confirm click, power hold on a shared GPIO
+  DigitalFiveKey,           // 3 physical GPIO keys + synthesized events (Murphy M3)
+  DigitalTwoButton,         // short up/down; holds synthesize back/confirm/power
 };
 
 // Panel controller silicon. Drivers are selected from this at begin().
@@ -383,7 +390,7 @@ enum class DisplayController : uint8_t {
 };
 
 // Optional capacitive touch controller.
-enum class TouchController : uint8_t { None, Chsc6x, Gt911, Ft5x06 };
+enum class TouchController : uint8_t { None, Chsc6x, Gt911, Ft5x06, Ft6336u };
 
 // Optional audio output path. Murphy M3 ships an ES8388-compatible stereo
 // codec (I2S slave, control over the shared touch I2C bus) — the contract was
@@ -687,8 +694,8 @@ constexpr TouchConfig NO_TOUCH = {TouchController::None,
 // portrait 540x960 frame on the landscape 960x540 panel, so swap axes into the
 // panel-native display frame before app-level orientation mapping.
 constexpr TouchConfig LILYGO_T5_PRO_GT911 = {
-    TouchController::Gt911, 39, 40, 3, 9, 0x5D, 0, 959, 0, 539, false, 0x14, false, true, PIN_UNASSIGNED, true,
-    false, true};  // powerEnable, swapXY=true, flipX=false, flipY=true
+    TouchController::Gt911, 39,   40,    3,   9, 0x5D, 0, 959, 0, 539, false, 0x14, false, true,
+    PIN_UNASSIGNED,         true, false, true};  // powerEnable, swapXY=true, flipX=false, flipY=true
 constexpr FrontlightConfig NO_FRONTLIGHT = {PIN_UNASSIGNED, 0, 0, true};
 constexpr AudioConfig NO_AUDIO = {AudioOutput::None,
                                   PIN_UNASSIGNED,
@@ -900,9 +907,18 @@ constexpr BoardProfile M5STACK_PAPER_COLOR = {Board::M5StackPaperColor,
 
 // Passive beeper switched by an NMOS from the 3V3_L2 core rail, gate on ESP
 // GPIO42 — a plain LEDC tone pin for the Buzzer lib, no codec on board.
-constexpr AudioConfig PAPER_MONO_AUDIO = {AudioOutput::None, PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED,
-                                          PIN_UNASSIGNED,    PIN_UNASSIGNED, true,           PIN_UNASSIGNED,
-                                          PIN_UNASSIGNED,    PIN_UNASSIGNED, 0,              42};
+constexpr AudioConfig PAPER_MONO_AUDIO = {AudioOutput::None,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          true,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          PIN_UNASSIGNED,
+                                          0,
+                                          42};
 
 // Frontlight: AW9967 boost LED driver whose CTRL input is the M5PM1's GPIO3
 // routed to its PWM0 engine (5 kHz, 12-bit) — no ESP pin involved. The AW9967
@@ -937,8 +953,8 @@ constexpr BoardProfile PAPER_MONO = {
     // portrait 480x800 frame, so swap it into the panel-native 800x480 frame.
     // Paper Mono's EPD source is rotated 180 degrees by the board profile;
     // flip the post-swap Y axis so touch follows the displayed framebuffer.
-    {TouchController::Ft5x06, 47, 48, 4, PIN_UNASSIGNED, 0x38, 0, 799, 0, 479,
-     false, 0, true, false, PIN_UNASSIGNED, true, false, true},
+    {TouchController::Ft5x06, 47, 48, 4, PIN_UNASSIGNED, 0x38, 0, 799, 0, 479, false, 0, true, false, PIN_UNASSIGNED,
+     true, false, true},
     PAPER_MONO_FRONTLIGHT,
     PAPER_MONO_AUDIO,
     PAPER_MONO_LEDS,
@@ -984,6 +1000,73 @@ constexpr BoardProfile MURPHY_M3 = {
     NO_SDMMC,
     NO_GAUGE};
 
+// --- Murphy M4 — ESP32-S3R8, SSD1677 (480x800 portrait), FT6336U touch, dual frontlight ---
+// Touch wiring below follows the CrossPoint-derived Murphy Reader v1.2.16
+// implementation recovered from its ESP-IDF image. GPIO10 is the independent
+// SD power gate and GPIO4 is the display clock; neither is part of touch I2C.
+// Confirmed pins: display MOSI=3 SCK=4 CS=5 DC=6 RST=7 BUSY=8, SD CLK=16 CMD=15
+// D0=17 D1=18 D2=11 D3=14 power=10(active LOW), touch SDA=10 SCL=4 INT=44 power=45(active LOW).
+constexpr BoardProfile MURPHY_M4 = {
+    Board::MurphyM4,
+    "murphy_m4",
+    InputStyle::DigitalFiveKey,
+    DisplayController::SSD1677,
+    // The GDEQ0426T82 panel has 800 source lines and 480 gate lines — landscape
+    // regardless of physical housing orientation. SSD1677 gate count = height-1 =
+    // 479, matching the factory firmware. The M4 physically mounts this landscape
+    // panel in a portrait housing; a software rotation will be added later.
+    800,
+    480,
+    // SSD1677 SPI: SCLK=4 (shared with I2C SCL), MOSI=3, CS=5, DC=6, RST=7, BUSY=8
+    {4, 3, 5, 6, 7, 8, PIN_UNASSIGNED},
+    20000000,  // 20 MHz — conservative start; SSD1677 supports up to 40 MHz
+    // SD power via GPIO10 active-LOW. SPI pins unused; SDMMC wiring below.
+    {PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, 10, false, 0, false},
+    // {back, confirm, left, right, up, down, power, powerActiveHigh}
+    // top=GPIO1(up/prev), middle=GPIO2(down/next), bottom=GPIO0(confirm+power shared, same as M3)
+    {PIN_UNASSIGNED, 0, PIN_UNASSIGNED, PIN_UNASSIGNED, 1, 2, 0, false},
+    9,               // battery ADC, measured with a 2:1 divider on hardware
+    PIN_UNASSIGNED,  // batteryChargeStatus
+    2.0f,
+    PIN_UNASSIGNED,  // usbDetect: native USB, no dedicated detect GPIO
+    // Murphy Reader v1.2.16: SDA=GPIO13, SCL=GPIO12, address=0x2E.
+    // INT=44 (active LOW), touch power=GPIO45 (active LOW, PMOS)
+    // Physical sensor is portrait (X:0-479, Y:0-799), landscape panel: swapXY=true.
+    // {ctrl,sda,scl,irq,rst,addr,minX,maxX,minY,maxY,synthConfirm,altAddr,irqActiveLow,gt911Byte0,
+    //  powerEnable,swapXY,flipX,flipY,hasHomeKey,powerEnableActiveHigh}
+    {TouchController::Ft6336u,
+     13,
+     12,
+     44,
+     7,
+     0x2E,
+     0,
+     799,
+     0,
+     479,
+     false,
+     0,
+     true,
+     false,
+     45,
+     true,
+     false,
+     true,
+     false,
+     false},
+    // Dual-channel frontlight: cool=GPIO47, warm=GPIO48, 25 kHz / 10-bit PWM, active-HIGH
+    {47, 25000, 10, true, 48},
+    NO_AUDIO,
+    NO_LEDS,
+    NO_FLIP,
+    // 4-bit SDMMC: CLK=16, CMD=15, D0=17, D1=18, D2=11, D3=14
+    {16, 15, 17, 18, 11, 14, 4},
+    NO_GAUGE,
+    NO_MIC,
+    NO_SENSORS,
+    1.2f,  // uiScale: touch device
+};
+
 // --- de-link (X4-class GDEQ0426T82 panel on ESP32-S3) — SSD1677 + frontlight ---
 // Reuses the SSD1677 driver (same controller/panel as X4); differs at the board
 // level: S3 MCU, SDMMC SD, warm/cool PWM frontlight.
@@ -1005,7 +1088,7 @@ constexpr BoardProfile DE_LINK = {Board::DeLink,
                                   // the wiring is in the sdmmc field below. These SPI sd pins are unused.
                                   {39, 38, 40, 41, PIN_UNASSIGNED, true, 0},
                                   {0, 1, 2, 3, 4, 5, 3, true},  // power button active-HIGH (INPUT_PULLDOWN) on de-link
-                                  4,  // batteryAdc GPIO4
+                                  4,                            // batteryAdc GPIO4
                                   PIN_UNASSIGNED,
                                   2.0f,
                                   PIN_UNASSIGNED,
@@ -1111,7 +1194,7 @@ constexpr BoardProfile M5PAPER_V11 = {
     // flipY=true keeps the back gesture upright (silicon (0,0) = physical top-left, from the
     // working back-gesture corner); flipX=false (X was never mirrored).
     {TouchController::Gt911, 21, 22, 36, PIN_UNASSIGNED, 0x5D, 0, 959, 0, 539, false, 0x14, false,
-     true,  // gt911CoordsAtByte0: reports coords at byte 0 (no track-id) on M5Paper
+     true,                                // gt911CoordsAtByte0: reports coords at byte 0 (no track-id) on M5Paper
      PIN_UNASSIGNED, true, false, true},  // powerEnable, swapXY=true, flipX=false, flipY=true
     NO_FRONTLIGHT,
     NO_AUDIO,
@@ -1325,8 +1408,26 @@ constexpr BoardProfile XTEINK_X4_PRO = {
     // post-swap panel axes. Coords start at byte 0 of the 0x8150 read → gt911CoordsAtByte0=true.
     // flipX/flipY pending a corner-tap test. {ctrl,sda,scl,irq,rst,addr,rawMinX,rawMaxX,rawMinY,rawMaxY,
     //  synthConfirm,altAddr,irqActiveLow,coordsAtByte0,powerEnable,swapXY,flipX,flipY,hasHomeKey,pwrActiveHigh}
-    {TouchController::Gt911, 39, 38, 10, 4, 0x5D, 0, 799, 0, 479, false, 0x14, false, true, 2,
-     true, false, true, true, false},  // swapXY + flipY (confirmed by corner-tap); powerEnable=GPIO2 active-LOW; hasHomeKey
+    {TouchController::Gt911,
+     39,
+     38,
+     10,
+     4,
+     0x5D,
+     0,
+     799,
+     0,
+     479,
+     false,
+     0x14,
+     false,
+     true,
+     2,
+     true,
+     false,
+     true,
+     true,
+     false},  // swapXY + flipY (confirmed by corner-tap); powerEnable=GPIO2 active-LOW; hasHomeKey
     // Frontlight: dual warm/cold LEDC PWM with color temperature (NVS lightWarmValue/
     // lightColdValue/lightCT/lightBri/lightOn). Recovered from the OEM LEDC init (IROM
     // 0x420a2130 → helper 0x420a20c0): two channels — GPIO8 on LEDC ch4 and GPIO9 on ch5 —
@@ -1391,7 +1492,8 @@ constexpr uint32_t MAX_FRAMEBUFFER_BYTES = cmax(
                    FREEINK_DEVICE_X4PRO ? panelBytes(XTEINK_X4_PRO) : 0u)),
          cmax(cmax(FREEINK_DEVICE_STICKY ? panelBytes(STICKY) : 0u,
                    FREEINK_DEVICE_PAPERMONO ? panelBytes(PAPER_MONO) : 0u),
-              FREEINK_DEVICE_PAPERS3 ? panelBytes(M5PAPER_S3) : 0u)));
+              cmax(FREEINK_DEVICE_PAPERS3 ? panelBytes(M5PAPER_S3) : 0u,
+                   FREEINK_DEVICE_MURPHY_M4 ? panelBytes(MURPHY_M4) : 0u))));
 
 // Compile-time default device — the profile ACTIVE starts as. With a single
 // device in the build this is the only device; with several same-MCU devices it
@@ -1400,6 +1502,8 @@ constexpr uint32_t MAX_FRAMEBUFFER_BYTES = cmax(
 constexpr BoardProfile DEFAULT_DEVICE = PAPER_MONO;
 #elif FREEINK_DEVICE_M5
 constexpr BoardProfile DEFAULT_DEVICE = M5STACK_PAPER_COLOR;
+#elif FREEINK_DEVICE_MURPHY_M4
+constexpr BoardProfile DEFAULT_DEVICE = MURPHY_M4;
 #elif FREEINK_DEVICE_MURPHY
 constexpr BoardProfile DEFAULT_DEVICE = MURPHY_M3;
 #elif FREEINK_DEVICE_DELINK
@@ -1454,6 +1558,11 @@ inline bool selectDevice(Board which) {
 #if FREEINK_DEVICE_MURPHY
     case Board::MurphyM3:
       ACTIVE = MURPHY_M3;
+      break;
+#endif
+#if FREEINK_DEVICE_MURPHY_M4
+    case Board::MurphyM4:
+      ACTIVE = MURPHY_M4;
       break;
 #endif
 #if FREEINK_DEVICE_DELINK
@@ -1512,9 +1621,7 @@ inline bool isX4Pro() { return ACTIVE.board == Board::XteinkX4Pro; }
 inline bool isPaperMono() { return ACTIVE.board == Board::PaperMono; }
 inline bool hasTouch() { return ACTIVE.touch.controller != TouchController::None; }
 inline bool hasHomeKey() { return ACTIVE.touch.hasHomeKey; }
-inline bool hasPwmFrontlight() {
-  return ACTIVE.frontlight.gpio != PIN_UNASSIGNED || ACTIVE.frontlight.viaPm1Pwm;
-}
+inline bool hasPwmFrontlight() { return ACTIVE.frontlight.gpio != PIN_UNASSIGNED || ACTIVE.frontlight.viaPm1Pwm; }
 inline bool hasAudio() { return ACTIVE.audio.output != AudioOutput::None; }
 
 // Safety guard: a power-latch pin must never coincide with a display or SDMMC
@@ -1529,8 +1636,7 @@ inline bool latchConflictsWithBus(int8_t pin) {
   const DisplayPins& d = ACTIVE.display;
   if (pin == d.sclk || pin == d.mosi || pin == d.cs || pin == d.dc || pin == d.rst || pin == d.busy) return true;
   const SdmmcPins& s = ACTIVE.sdmmc;
-  if (s.busWidth != 0 &&
-      (pin == s.clk || pin == s.cmd || pin == s.d0 || pin == s.d1 || pin == s.d2 || pin == s.d3)) {
+  if (s.busWidth != 0 && (pin == s.clk || pin == s.cmd || pin == s.d0 || pin == s.d1 || pin == s.d2 || pin == s.d3)) {
     return true;
   }
   return false;

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -25,6 +25,10 @@ class FrontlightManager {
   // this is the TOTAL brightness; the current color-temperature split is preserved.
   void setBrightness(uint8_t percent);
 
+  // Set brightness with 8-bit control and a perceptual curve. Level 1 maps to the
+  // smallest non-zero hardware duty, making dim night reading possible.
+  void setBrightnessLevel(uint8_t level);
+
   // Convenience: fully off / restore last brightness.
   void off();
   void on();
@@ -56,6 +60,7 @@ class FrontlightManager {
   }
 
   uint8_t brightness() const { return _brightness; }
+  uint8_t brightnessLevel() const { return _brightnessLevel; }
   uint8_t colorTemperature() const { return _warmPercent; }
 
  private:
@@ -66,6 +71,8 @@ class FrontlightManager {
 
   bool _begun = false;
   uint8_t _brightness = 0;
+  uint8_t _brightnessLevel = 0;
+  bool _useLevel = false;
   uint8_t _lastBrightness = 50;
   uint8_t _warmPercent = 50;  // neutral by default
 };

--- a/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
+++ b/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
@@ -39,9 +39,7 @@ uint32_t physicalDuty(uint32_t logicalDuty, uint32_t full, bool activeHigh) {
 }
 
 #if defined(ARDUINO) && ESP_ARDUINO_VERSION_MAJOR >= 3
-void attachChannel(int8_t gpio, uint8_t /*ch*/, uint32_t freq, uint8_t bits) {
-  ledcAttach(gpio, freq, bits);
-}
+void attachChannel(int8_t gpio, uint8_t /*ch*/, uint32_t freq, uint8_t bits) { ledcAttach(gpio, freq, bits); }
 void writeChannel(int8_t gpio, uint8_t /*ch*/, uint32_t duty) { ledcWrite(gpio, duty); }
 #else
 void attachChannel(int8_t gpio, uint8_t ch, uint32_t freq, uint8_t bits) {
@@ -90,7 +88,13 @@ void FrontlightManager::apply() {
   // Splitting integer percentages first loses both fractional parts at low
   // levels: brightness=1, warmth=50 previously became cool=0% + warm=0%.
   // Splitting the total duty also keeps cool+warm equal to the requested total.
-  const uint32_t totalDuty = (static_cast<uint32_t>(_brightness) * full + 50u) / 100u;
+  uint32_t totalDuty = 0;
+  if (_useLevel && _brightnessLevel > 0) {
+    const uint32_t n = static_cast<uint32_t>(_brightnessLevel - 1u);
+    totalDuty = 1u + (n * n * (full - 1u)) / (254u * 254u);
+  } else if (!_useLevel) {
+    totalDuty = (static_cast<uint32_t>(_brightness) * full + 50u) / 100u;
+  }
   uint32_t warmDuty = 0;
   uint32_t coolDuty = totalDuty;
   if (dual) {
@@ -109,10 +113,23 @@ void FrontlightManager::setBrightness(uint8_t percent) {
 #if FREEINK_CAP_FRONTLIGHT
   if (percent > 100) percent = 100;
   _brightness = percent;
+  _brightnessLevel = (static_cast<uint16_t>(percent) * 255u) / 100u;
+  _useLevel = false;
   if (percent > 0) _lastBrightness = percent;
   apply();
 #else
   (void)percent;
+#endif
+}
+
+void FrontlightManager::setBrightnessLevel(uint8_t level) {
+#if FREEINK_CAP_FRONTLIGHT
+  _brightnessLevel = level;
+  _brightness = (static_cast<uint16_t>(level) * 100u) / 255u;
+  _useLevel = true;
+  apply();
+#else
+  (void)level;
 #endif
 }
 

--- a/libs/hardware/Imu/src/Imu.cpp
+++ b/libs/hardware/Imu/src/Imu.cpp
@@ -25,8 +25,8 @@ constexpr uint8_t CTRL2_G_104HZ_245DPS = 0x40;
 constexpr uint8_t CTRL3_C_BDU_IF_INC = 0x44;  // BDU=1, IF_INC=1 (block update + auto-increment)
 
 // Sensitivities for the scales above (datasheet "mechanical characteristics").
-constexpr float ACCEL_G_PER_LSB = 0.061f / 1000.0f;   // 0.061 mg/LSB at ±2 g
-constexpr float GYRO_DPS_PER_LSB = 8.75f / 1000.0f;    // 8.75 mdps/LSB at ±245 dps
+constexpr float ACCEL_G_PER_LSB = 0.061f / 1000.0f;  // 0.061 mg/LSB at ±2 g
+constexpr float GYRO_DPS_PER_LSB = 8.75f / 1000.0f;  // 8.75 mdps/LSB at ±245 dps
 
 // QMI8658 register map.
 constexpr uint8_t QMI8658_REG_WHO_AM_I = 0x00;
@@ -74,6 +74,7 @@ void ensureWire() {
       0;
 #endif
   if (g_wireReady[bus]) return;
+  if (s.i2cSda < 0 || s.i2cScl < 0) return;  // no sensor bus on this board
   auto& wire = sensorWire();
   wire.begin(s.i2cSda, s.i2cScl, s.i2cHz);
   g_wireReady[bus] = true;
@@ -109,8 +110,7 @@ bool powerDownQmi8658(uint8_t addr) {
   // fails, still try to stop the internal oscillator. This is also used as the
   // cleanup path after a partially failed begin().
   const bool sensorsDisabled = writeReg(addr, QMI8658_REG_CTRL7, QMI8658_CTRL7_DISABLE_ALL);
-  const bool oscillatorDisabled =
-      writeReg(addr, QMI8658_REG_CTRL1, QMI8658_CTRL1_BASE | QMI8658_CTRL1_SENSOR_DISABLE);
+  const bool oscillatorDisabled = writeReg(addr, QMI8658_REG_CTRL1, QMI8658_CTRL1_BASE | QMI8658_CTRL1_SENSOR_DISABLE);
   return sensorsDisabled && oscillatorDisabled;
 }
 
@@ -138,8 +138,7 @@ bool Imu::begin() {
       // SA0 selects between 0x6A and 0x6B. X3 production revisions have used
       // both, so treat the profile address as a preference rather than a
       // guarantee. This restores the fallback used by the pre-SDK X3 driver.
-      const uint8_t alternateAddr =
-          configuredAddr == QMI8658_ADDR_6A ? QMI8658_ADDR_6B : QMI8658_ADDR_6A;
+      const uint8_t alternateAddr = configuredAddr == QMI8658_ADDR_6A ? QMI8658_ADDR_6B : QMI8658_ADDR_6A;
       if (qmi8658PresentAt(configuredAddr)) {
         addr_ = configuredAddr;
       } else if (qmi8658PresentAt(alternateAddr)) {
@@ -148,12 +147,11 @@ bool Imu::begin() {
         return false;
       }
 
-      const bool configured =
-          writeReg(addr_, QMI8658_REG_CTRL7, QMI8658_CTRL7_DISABLE_ALL) &&
-          writeReg(addr_, QMI8658_REG_CTRL1, QMI8658_CTRL1_BASE) &&
-          writeReg(addr_, QMI8658_REG_CTRL2, QMI8658_CTRL2_FS_2G | QMI8658_CTRL2_ODR_28HZ) &&
-          writeReg(addr_, QMI8658_REG_CTRL3, QMI8658_CTRL3_FS_512DPS | QMI8658_CTRL3_ODR_28HZ) &&
-          writeReg(addr_, QMI8658_REG_CTRL7, QMI8658_CTRL7_ACC_GYRO_ENABLE);
+      const bool configured = writeReg(addr_, QMI8658_REG_CTRL7, QMI8658_CTRL7_DISABLE_ALL) &&
+                              writeReg(addr_, QMI8658_REG_CTRL1, QMI8658_CTRL1_BASE) &&
+                              writeReg(addr_, QMI8658_REG_CTRL2, QMI8658_CTRL2_FS_2G | QMI8658_CTRL2_ODR_28HZ) &&
+                              writeReg(addr_, QMI8658_REG_CTRL3, QMI8658_CTRL3_FS_512DPS | QMI8658_CTRL3_ODR_28HZ) &&
+                              writeReg(addr_, QMI8658_REG_CTRL7, QMI8658_CTRL7_ACC_GYRO_ENABLE);
       if (!configured) {
         // A failed setup must not strand a previously running sensor in its
         // multi-milliamp active mode. The digital interface remains available

--- a/libs/hardware/InputManager/include/InputManager.h
+++ b/libs/hardware/InputManager/include/InputManager.h
@@ -15,7 +15,7 @@
 #include <freertos/task.h>
 
 class InputManager {
-public:
+ public:
   InputManager();
   void begin();
   uint8_t getState();
@@ -66,12 +66,11 @@ public:
   // stay correct.
   static constexpr int BUTTON_ADC_PIN_1 = 1;
   static constexpr int BUTTON_ADC_PIN_2 = 2;
-  static constexpr int POWER_BUTTON_PIN =
-      BoardConfig::DEFAULT_DEVICE.input.power;
+  static constexpr int POWER_BUTTON_PIN = BoardConfig::DEFAULT_DEVICE.input.power;
 
   bool isPowerButtonPressed() const;
 
-  static const char *getButtonName(uint8_t buttonIndex);
+  static const char* getButtonName(uint8_t buttonIndex);
 
   // --- Capacitive touch (inert unless BoardConfig::ACTIVE.touch is configured)
   // ---
@@ -95,32 +94,31 @@ public:
   // One-shot tap on release. Returns the original touch-down position
   // normalized to 0..1 in the panel's native frame; false when no tap completed
   // this update.
-  bool wasTouchTap(float &nx, float &ny) const;
+  bool wasTouchTap(float& nx, float& ny) const;
   // Press edge with the touch-down position normalized in the panel's native
   // frame.
-  bool wasTouchPressedAt(float &nx, float &ny) const;
+  bool wasTouchPressedAt(float& nx, float& ny) const;
   // True while the current touch is still a tap candidate: finger down,
   // movement remains within tap slop. Writes the original touch-down position
   // and held time.
-  bool isTouchTapCandidate(float &nx, float &ny, unsigned long &heldMs) const;
+  bool isTouchTapCandidate(float& nx, float& ny, unsigned long& heldMs) const;
   // True while a touch is down; writes the CURRENT contact position normalized
   // to 0..1 in the panel's native frame. Unlike #isTouchTapCandidate there is
   // no tap-slop gate — the position follows the moving finger, for drag
   // interactions (sliders). Callers own any threshold/hysteresis they need.
-  bool isTouchHeldAt(float &nx, float &ny) const;
+  bool isTouchHeldAt(float& nx, float& ny) const;
   // Duration (ms) of the last touch contact, latched on release.
   unsigned long lastTouchHeldMs() const;
   // Swipe gesture on release. Returns start/end positions normalized in the
   // panel's native frame; callers map orientation and check this before tap.
-  bool wasSwipe(float &nxStart, float &nyStart, float &nxEnd,
-                float &nyEnd) const;
+  bool wasSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) const;
   // One-shot long-press: fires WHILE the finger is still down, once a
   // stationary contact (within tap slop) has been held TOUCH_LONG_PRESS_MS.
   // Position is the touch-down point, normalized like wasTouchTap. Fires at
   // most once per contact. Detection alone has no side effects; callers that
   // act on it should call suppressTouchContact() so the eventual lift cannot
   // also tap. Cleared each #update().
-  bool wasTouchLongPress(float &nx, float &ny) const;
+  bool wasTouchLongPress(float& nx, float& ny) const;
   // Ignore the remainder of the current contact: tap, swipe, release,
   // tap-candidate and held queries report nothing until the finger lifts and
   // the release edge has passed, then a fresh contact is delivered normally.
@@ -168,23 +166,22 @@ public:
   //
   // When async polling is active the app must NOT call update()/wasPressed()
   // itself; the task owns the edge state. Drain with popPress() instead.
-  void beginAsync(uint8_t taskPriority = 2, uint32_t pollMs = 15,
-                  uint8_t queueLen = 32);
+  void beginAsync(uint8_t taskPriority = 2, uint32_t pollMs = 15, uint8_t queueLen = 32);
 
   // Pop the next latched button index (BTN_*) into `button`. Returns false when
   // no press is pending (or async polling was never started).
-  bool popPress(uint8_t &button);
+  bool popPress(uint8_t& button);
 
   // Pop the next latched touch tap (normalized 0..1 panel-native coordinates,
   // same frame as wasTouchTap). The async task queues every completed tap, so
   // taps that land while the app thread renders or waits are never lost —
   // drain and route them afterwards. Returns false when no tap is pending.
-  bool popTouchTap(float &nx, float &ny);
+  bool popTouchTap(float& nx, float& ny);
 
   // Pop the next latched swipe gesture (normalized 0..1 panel-native start/end
   // coordinates, same frame as wasSwipe). Like taps, async polling queues
   // swipes so gestures that complete during e-paper refreshes are not lost.
-  bool popSwipe(float &nxStart, float &nyStart, float &nxEnd, float &nyEnd);
+  bool popSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd);
 
   // --- Diagnostics -----------------------------------------------------------
   // A live sample of one button-group ADC pin: the raw reading plus the BTN_*
@@ -195,17 +192,17 @@ public:
   // drifted divider whose reading no longer lands in the band the firmware
   // expects — visible from the raw value regardless of how it classifies.
   struct ButtonAdcSample {
-    int pin;    // GPIO sampled (BUTTON_ADC_PIN_1 / BUTTON_ADC_PIN_2)
-    int raw;    // raw analogRead() value, or -1 if this board has no ADC ladder
-    int button; // classified BTN_* index, or -1 for no match
+    int pin;     // GPIO sampled (BUTTON_ADC_PIN_1 / BUTTON_ADC_PIN_2)
+    int raw;     // raw analogRead() value, or -1 if this board has no ADC ladder
+    int button;  // classified BTN_* index, or -1 for no match
   };
 
   // Sample both button-group ADC pins now (synchronous analogRead). Safe to
   // call alongside async polling. On boards without the Xteink ADC ladder both
   // samples report raw = -1, button = -1.
-  void readButtonAdc(ButtonAdcSample &group1, ButtonAdcSample &group2);
+  void readButtonAdc(ButtonAdcSample& group1, ButtonAdcSample& group2);
 
-private:
+ private:
   static ButtonHook s_buttonHook;
 
   QueueHandle_t _asyncQueue = nullptr;
@@ -213,7 +210,7 @@ private:
   QueueHandle_t _asyncSwipeQueue = nullptr;
   TaskHandle_t _asyncTask = nullptr;
   uint32_t _asyncPollMs = 15;
-  static void asyncTaskTrampoline(void *self);
+  static void asyncTaskTrampoline(void* self);
   void asyncPoll();
 
   int getButtonFromADC(int adcValue, const int ranges[], int numButtons);
@@ -227,22 +224,22 @@ private:
   // Touch backend. Compiled only when FREEINK_CAP_TOUCH is set; dispatches on
   // BoardConfig::ACTIVE.touch.controller (CHSC6x, GT911, or FT5x06/FT6336).
   void beginTouch();
-  uint8_t serviceTouch(); // runs the machine; returns synthesized button mask
+  uint8_t serviceTouch();  // runs the machine; returns synthesized button mask
   void updateTouchFromIrq(unsigned long now,
-                          int irqRaw); // CHSC6x I2C poll + touch-bit gate
-  void pollGt911(unsigned long now);   // GT911 polled read
+                          int irqRaw);  // CHSC6x I2C poll + touch-bit gate
+  void pollGt911(unsigned long now);    // GT911 polled read
   void beginFt5x06();
   void pollFt5x06(unsigned long now);
   bool ft5x06WriteReg(uint8_t reg, uint8_t value);
   bool ft5x06ReadReg(uint8_t reg, uint8_t* buf, uint8_t len);
-  bool readChsc6xPoint(TouchPoint &point);
-  bool decodeChsc6xFrame(const uint8_t *data, size_t len,
-                         TouchPoint &point) const;
-  uint16_t mapTouchAxis(uint16_t raw, uint16_t rawMin, uint16_t rawMax,
-                        uint16_t outMax) const;
+  bool readChsc6xPoint(TouchPoint& point);
+  bool decodeChsc6xFrame(const uint8_t* data, size_t len, TouchPoint& point) const;
+  uint16_t mapTouchAxis(uint16_t raw, uint16_t rawMin, uint16_t rawMax, uint16_t outMax) const;
   void beginGt911();
-  bool gt911ReadReg(uint16_t reg, uint8_t *buf, uint8_t len);
+  bool gt911ReadReg(uint16_t reg, uint8_t* buf, uint8_t len);
   void gt911ClearStatus();
+  void beginFt6336u();
+  void pollFt6336u(unsigned long now);
 
   uint8_t currentState;
   uint8_t lastState;
@@ -263,41 +260,33 @@ private:
   unsigned long twoButtonPressStart;
   bool twoButtonLongPressActive;
 
-  bool touchDataEnabled = false; // I2C up, controller present
-  uint8_t gt911Addr = 0;         // resolved GT911 address (0 until probed)
-  unsigned long touchIrqPulseUntil =
-      0;                         // synthesized-confirm window after a press
-  unsigned long touchReadAt = 0; // next scheduled I2C poll
+  bool touchDataEnabled = false;         // I2C up, controller present
+  uint8_t gt911Addr = 0;                 // resolved GT911 address (0 until probed)
+  unsigned long touchIrqPulseUntil = 0;  // synthesized-confirm window after a press
+  unsigned long touchReadAt = 0;         // next scheduled I2C poll
   unsigned long touchReleaseAt = 0;
   bool touchPressed = false;
   bool touchPressedEvent = false;
   bool touchReleasedEvent = false;
-  bool touchHomeKeyEvent = false; // GT911 capacitive home key, press edge
+  bool touchHomeKeyEvent = false;  // GT911 capacitive home key, press edge
   bool touchHomeKeyDown = false;
-  bool touchHomeKeyTapEvent = false; // short-press release edge (one-shot)
-  bool touchHomeKeyLongEvent =
-      false; // held past the long-press threshold (one-shot)
-  bool touchHomeKeyLongFired = false; // latched for the current hold so long
-                                      // fires once and suppresses the tap
+  bool touchHomeKeyTapEvent = false;   // short-press release edge (one-shot)
+  bool touchHomeKeyLongEvent = false;  // held past the long-press threshold (one-shot)
+  bool touchHomeKeyLongFired = false;  // latched for the current hold so long
+                                       // fires once and suppresses the tap
   unsigned long touchHomeKeyDownAt = 0;
   static constexpr unsigned long HOME_KEY_LONG_PRESS_MS = 700;
   TouchPoint touchPoint = {false, 0, 0, 0};
-  TouchPoint touchDownPoint = {
-      false, 0, 0, 0}; // first sample of the current contact (tap routing)
-  TouchPoint touchUpPoint = {false, 0, 0,
-                             0}; // last sample before release (swipe routing)
-  unsigned long lastTouchHeldDurationMs =
-      0; // contact duration, latched at release
-  bool touchMovedBeyondTapSlop =
-      false; // cancels stationary hold/long-press classification
-  bool touchMovedBeyondTapReleaseSlop =
-      false; // cancels tap-on-release once motion reaches swipe distance
-  bool touchLongPressEvent = false; // one-shot, mirrors touchHomeKeyLongEvent
-  bool touchLongPressFired =
-      false; // latched for the current contact so long-press fires once
-  bool touchSuppressed = false; // suppressTouchContact() latch; holds through
-                                // the release-edge frame, cleared in
-                                // serviceTouch() once the contact is over
+  TouchPoint touchDownPoint = {false, 0, 0, 0};  // first sample of the current contact (tap routing)
+  TouchPoint touchUpPoint = {false, 0, 0, 0};    // last sample before release (swipe routing)
+  unsigned long lastTouchHeldDurationMs = 0;     // contact duration, latched at release
+  bool touchMovedBeyondTapSlop = false;          // cancels stationary hold/long-press classification
+  bool touchMovedBeyondTapReleaseSlop = false;   // cancels tap-on-release once motion reaches swipe distance
+  bool touchLongPressEvent = false;              // one-shot, mirrors touchHomeKeyLongEvent
+  bool touchLongPressFired = false;              // latched for the current contact so long-press fires once
+  bool touchSuppressed = false;                  // suppressTouchContact() latch; holds through
+                                                 // the release-edge frame, cleared in
+                                                 // serviceTouch() once the contact is over
 
   static constexpr int NUM_BUTTONS_1 = 4;
   static const int ADC_RANGES_1[];
@@ -313,20 +302,17 @@ private:
 
   // Touch timing / protocol constants (ported from the Murphy M3 CHSC6x
   // driver).
-  static constexpr unsigned long TOUCH_IRQ_PULSE_MS =
-      120; // release hold-over after last valid read
-  static constexpr unsigned long TOUCH_SAMPLE_DELAY_MS = 8; // I2C poll cadence
+  static constexpr unsigned long TOUCH_IRQ_PULSE_MS = 120;   // release hold-over after last valid read
+  static constexpr unsigned long TOUCH_SAMPLE_DELAY_MS = 8;  // I2C poll cadence
   static constexpr int TOUCH_TAP_SLOP_PX = 28;
   static constexpr int TOUCH_SWIPE_MIN_PX = 60;
-  static constexpr int TOUCH_TAP_RELEASE_SLOP_PX =
-      TOUCH_SWIPE_MIN_PX - 1;
+  static constexpr int TOUCH_TAP_RELEASE_SLOP_PX = TOUCH_SWIPE_MIN_PX - 1;
   static constexpr unsigned long TOUCH_SWIPE_MAX_MS = 700;
-  static constexpr unsigned long TOUCH_LONG_PRESS_MS =
-      500; // shorter than HOME_KEY_LONG_PRESS_MS: a screen hold has no button
-           // travel to absorb
+  static constexpr unsigned long TOUCH_LONG_PRESS_MS = 500;  // shorter than HOME_KEY_LONG_PRESS_MS: a screen hold has
+                                                             // no button travel to absorb
   static constexpr uint8_t TOUCH_READ_COMMAND = 0x00;
   static constexpr uint8_t TOUCH_FRAME_SIZE = 16;
 
-  static const char *BUTTON_NAMES[];
+  static const char* BUTTON_NAMES[];
   static bool s_sharedConfirmPowerShortPressEmitsPower;
 };

--- a/libs/hardware/InputManager/src/InputManager.cpp
+++ b/libs/hardware/InputManager/src/InputManager.cpp
@@ -3,6 +3,10 @@
 #if FREEINK_CAP_TOUCH
 #include <Wire.h>
 #include <driver/gpio.h>
+#if FREEINK_DEVICE_MURPHY_M4
+#include <driver/i2c_master.h>
+#include <esp_rom_sys.h>
+#endif
 #endif
 #if FREEINK_DEVICE_PAPERMONO
 #include <PaperMonoBoard.h>
@@ -29,27 +33,24 @@
 // being pressed. These ranges are based on real world values above, and are
 // much more tolerant of different devices than a fixed threshold check. They
 // are calculated by taking the midpoint of the pairs of averaged values above.
-const int InputManager::ADC_RANGES_1[] = {ADC_NO_BUTTON, 3100, 2090, 750,
-                                          INT32_MIN};
+const int InputManager::ADC_RANGES_1[] = {ADC_NO_BUTTON, 3100, 2090, 750, INT32_MIN};
 const int InputManager::ADC_RANGES_2[] = {ADC_NO_BUTTON, 1120, INT32_MIN};
-const char *InputManager::BUTTON_NAMES[] = {"Back", "Confirm", "Left", "Right",
-                                            "Up",   "Down",    "Power"};
+const char* InputManager::BUTTON_NAMES[] = {"Back", "Confirm", "Left", "Right", "Up", "Down", "Power"};
 
 namespace {
 int absInt(const int value) { return value < 0 ? -value : value; }
 
 #if defined(TOUCH_PROBE_DEBUG)
-void touchDebugPrintf(const char *format, ...) {
+void touchDebugPrintf(const char* format, ...) {
   char buf[192];
   va_list args;
   va_start(args, format);
   const int len = vsnprintf(buf, sizeof(buf), format, args);
   va_end(args);
-  if (len < 0)
-    return;
+  if (len < 0) return;
   const size_t n = strnlen(buf, sizeof(buf));
 #if FREEINK_LOG_TRANSPORT == FREEINK_LOG_TRANSPORT_USB_CDC_WRITE
-  Serial.write(reinterpret_cast<const uint8_t *>(buf), n);
+  Serial.write(reinterpret_cast<const uint8_t*>(buf), n);
 #elif FREEINK_LOG_TRANSPORT == FREEINK_LOG_TRANSPORT_ROM_PRINTF
   esp_rom_printf("%s", buf);
 #else
@@ -59,36 +60,42 @@ void touchDebugPrintf(const char *format, ...) {
 #endif
 }
 #endif
-} // namespace
+}  // namespace
 
 InputManager::InputManager()
-    : currentState(0), lastState(0), pressedEvents(0), releasedEvents(0),
-      lastDebounceTime(0), buttonPressStart(0), buttonPressFinish(0),
-      powerButtonPressStart(0), powerButtonPressFinish(0),
-      confirmBackPressStart(0), confirmBackPhysicalPressed(false),
-      confirmBackLongPressActive(false), confirmPowerPressStart(0),
-      confirmPowerPhysicalPressed(false), confirmPowerLongPressActive(false),
-      twoButtonPhysicalState(0), twoButtonPressStart(0),
+    : currentState(0),
+      lastState(0),
+      pressedEvents(0),
+      releasedEvents(0),
+      lastDebounceTime(0),
+      buttonPressStart(0),
+      buttonPressFinish(0),
+      powerButtonPressStart(0),
+      powerButtonPressFinish(0),
+      confirmBackPressStart(0),
+      confirmBackPhysicalPressed(false),
+      confirmBackLongPressActive(false),
+      confirmPowerPressStart(0),
+      confirmPowerPhysicalPressed(false),
+      confirmPowerLongPressActive(false),
+      twoButtonPhysicalState(0),
+      twoButtonPressStart(0),
       twoButtonLongPressActive(false) {}
 
 void InputManager::begin() {
-  if (BoardConfig::ACTIVE.inputStyle ==
-      BoardConfig::InputStyle::XteinkAdcLadder) {
+  if (BoardConfig::ACTIVE.inputStyle == BoardConfig::InputStyle::XteinkAdcLadder) {
     pinMode(BUTTON_ADC_PIN_1, INPUT);
     pinMode(BUTTON_ADC_PIN_2, INPUT);
-    pinMode(BoardConfig::ACTIVE.input.power,
-            BoardConfig::ACTIVE.input.powerActiveHigh ? INPUT_PULLDOWN
-                                                      : INPUT_PULLUP);
+    pinMode(BoardConfig::ACTIVE.input.power, BoardConfig::ACTIVE.input.powerActiveHigh ? INPUT_PULLDOWN : INPUT_PULLUP);
     analogSetAttenuation(ADC_11db);
     beginTouch();
     return;
   }
 
-  const int8_t pins[] = {
-      BoardConfig::ACTIVE.input.back, BoardConfig::ACTIVE.input.confirm,
-      BoardConfig::ACTIVE.input.left, BoardConfig::ACTIVE.input.right,
-      BoardConfig::ACTIVE.input.up,   BoardConfig::ACTIVE.input.down,
-      BoardConfig::ACTIVE.input.power};
+  const int8_t pins[] = {BoardConfig::ACTIVE.input.back, BoardConfig::ACTIVE.input.confirm,
+                         BoardConfig::ACTIVE.input.left, BoardConfig::ACTIVE.input.right,
+                         BoardConfig::ACTIVE.input.up,   BoardConfig::ACTIVE.input.down,
+                         BoardConfig::ACTIVE.input.power};
   for (const int8_t pin : pins) {
     if (pin >= 0) {
       pinMode(pin, INPUT_PULLUP);
@@ -97,8 +104,7 @@ void InputManager::begin() {
   beginTouch();
 }
 
-int InputManager::getButtonFromADC(const int adcValue, const int ranges[],
-                                   const int numButtons) {
+int InputManager::getButtonFromADC(const int adcValue, const int ranges[], const int numButtons) {
   for (int i = 0; i < numButtons; i++) {
     if (ranges[i + 1] < adcValue && adcValue <= ranges[i]) {
       return i;
@@ -108,12 +114,10 @@ int InputManager::getButtonFromADC(const int adcValue, const int ranges[],
   return -1;
 }
 
-void InputManager::readButtonAdc(ButtonAdcSample &group1,
-                                 ButtonAdcSample &group2) {
+void InputManager::readButtonAdc(ButtonAdcSample& group1, ButtonAdcSample& group2) {
   group1 = {BUTTON_ADC_PIN_1, -1, -1};
   group2 = {BUTTON_ADC_PIN_2, -1, -1};
-  if (BoardConfig::ACTIVE.inputStyle !=
-      BoardConfig::InputStyle::XteinkAdcLadder) {
+  if (BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::XteinkAdcLadder) {
     return;
   }
 
@@ -122,19 +126,16 @@ void InputManager::readButtonAdc(ButtonAdcSample &group1,
 
   group2.raw = analogRead(BUTTON_ADC_PIN_2);
   const int b2 = getButtonFromADC(group2.raw, ADC_RANGES_2, NUM_BUTTONS_2);
-  group2.button =
-      b2 >= 0 ? b2 + 4 : -1; // map group-2 local 0/1 to BTN_UP / BTN_DOWN
+  group2.button = b2 >= 0 ? b2 + 4 : -1;  // map group-2 local 0/1 to BTN_UP / BTN_DOWN
 }
 
 uint8_t InputManager::getState() {
   uint8_t state = 0;
 
-  if (BoardConfig::ACTIVE.inputStyle !=
-      BoardConfig::InputStyle::XteinkAdcLadder) {
+  if (BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::XteinkAdcLadder) {
     state = getDigitalState();
-    state |= serviceTouch(); // run the touch machine; OR any synthesized button
-    if (s_buttonHook)
-      state |= s_buttonHook(); // board buttons (e.g. I2C expander)
+    state |= serviceTouch();                    // run the touch machine; OR any synthesized button
+    if (s_buttonHook) state |= s_buttonHook();  // board buttons (e.g. I2C expander)
     return state;
   }
 
@@ -153,46 +154,36 @@ uint8_t InputManager::getState() {
   }
 
   // Read power button (polarity per board; X4 active-LOW, de-link active-HIGH)
-  const int powerActiveLevel =
-      BoardConfig::ACTIVE.input.powerActiveHigh ? HIGH : LOW;
+  const int powerActiveLevel = BoardConfig::ACTIVE.input.powerActiveHigh ? HIGH : LOW;
   if (digitalRead(BoardConfig::ACTIVE.input.power) == powerActiveLevel) {
     state |= (1 << BTN_POWER);
   }
 
   state |= serviceTouch();
-  if (s_buttonHook)
-    state |= s_buttonHook(); // board buttons (e.g. I2C expander)
+  if (s_buttonHook) state |= s_buttonHook();  // board buttons (e.g. I2C expander)
   return state;
 }
 
 InputManager::ButtonHook InputManager::s_buttonHook = nullptr;
 
-void InputManager::beginAsync(const uint8_t taskPriority, const uint32_t pollMs,
-                              const uint8_t queueLen) {
-  if (_asyncTask)
-    return; // already running
+void InputManager::beginAsync(const uint8_t taskPriority, const uint32_t pollMs, const uint8_t queueLen) {
+  if (_asyncTask) return;  // already running
   _asyncPollMs = pollMs;
   _asyncQueue = xQueueCreate(queueLen, sizeof(uint8_t));
-  if (!_asyncQueue)
-    return;
+  if (!_asyncQueue) return;
   _asyncTapQueue = xQueueCreate(queueLen, sizeof(float) * 2);
   _asyncSwipeQueue = xQueueCreate(queueLen, sizeof(float) * 4);
-  xTaskCreate(asyncTaskTrampoline, "fi_input", 4096, this, taskPriority,
-              &_asyncTask);
+  xTaskCreate(asyncTaskTrampoline, "fi_input", 4096, this, taskPriority, &_asyncTask);
 }
 
-void InputManager::asyncTaskTrampoline(void *self) {
-  static_cast<InputManager *>(self)->asyncPoll();
-}
+void InputManager::asyncTaskTrampoline(void* self) { static_cast<InputManager*>(self)->asyncPoll(); }
 
 void InputManager::asyncPoll() {
-  static const uint8_t kButtons[] = {BTN_BACK, BTN_CONFIRM, BTN_LEFT, BTN_RIGHT,
-                                     BTN_UP,   BTN_DOWN,    BTN_POWER};
+  static const uint8_t kButtons[] = {BTN_BACK, BTN_CONFIRM, BTN_LEFT, BTN_RIGHT, BTN_UP, BTN_DOWN, BTN_POWER};
   for (;;) {
     update();
     for (const uint8_t b : kButtons) {
-      if (wasPressed(b))
-        xQueueSend(_asyncQueue, &b, 0);
+      if (wasPressed(b)) xQueueSend(_asyncQueue, &b, 0);
     }
     float tap[2];
     if (_asyncTapQueue && wasTouchTap(tap[0], tap[1])) {
@@ -206,30 +197,24 @@ void InputManager::asyncPoll() {
   }
 }
 
-bool InputManager::popPress(uint8_t &button) {
-  if (!_asyncQueue)
-    return false;
+bool InputManager::popPress(uint8_t& button) {
+  if (!_asyncQueue) return false;
   return xQueueReceive(_asyncQueue, &button, 0) == pdTRUE;
 }
 
-bool InputManager::popTouchTap(float &nx, float &ny) {
-  if (!_asyncTapQueue)
-    return false;
+bool InputManager::popTouchTap(float& nx, float& ny) {
+  if (!_asyncTapQueue) return false;
   float tap[2];
-  if (xQueueReceive(_asyncTapQueue, tap, 0) != pdTRUE)
-    return false;
+  if (xQueueReceive(_asyncTapQueue, tap, 0) != pdTRUE) return false;
   nx = tap[0];
   ny = tap[1];
   return true;
 }
 
-bool InputManager::popSwipe(float &nxStart, float &nyStart, float &nxEnd,
-                            float &nyEnd) {
-  if (!_asyncSwipeQueue)
-    return false;
+bool InputManager::popSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) {
+  if (!_asyncSwipeQueue) return false;
   float swipe[4];
-  if (xQueueReceive(_asyncSwipeQueue, swipe, 0) != pdTRUE)
-    return false;
+  if (xQueueReceive(_asyncSwipeQueue, swipe, 0) != pdTRUE) return false;
   nxStart = swipe[0];
   nyStart = swipe[1];
   nxEnd = swipe[2];
@@ -237,44 +222,31 @@ bool InputManager::popSwipe(float &nxStart, float &nyStart, float &nxEnd,
   return true;
 }
 
-bool InputManager::isDigitalPressed(const int8_t pin) const {
-  return pin >= 0 && digitalRead(pin) == LOW;
-}
+bool InputManager::isDigitalPressed(const int8_t pin) const { return pin >= 0 && digitalRead(pin) == LOW; }
 
 uint8_t InputManager::getDigitalState() const {
   uint8_t state = 0;
 
-  if (BoardConfig::ACTIVE.inputStyle !=
-          BoardConfig::InputStyle::DigitalConfirmBackHold &&
-      BoardConfig::ACTIVE.inputStyle !=
-          BoardConfig::InputStyle::DigitalConfirmPowerHold) {
-    if (isDigitalPressed(BoardConfig::ACTIVE.input.back))
-      state |= (1 << BTN_BACK);
-    if (isDigitalPressed(BoardConfig::ACTIVE.input.confirm))
-      state |= (1 << BTN_CONFIRM);
+  if (BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::DigitalConfirmBackHold &&
+      BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::DigitalConfirmPowerHold) {
+    if (isDigitalPressed(BoardConfig::ACTIVE.input.back)) state |= (1 << BTN_BACK);
+    if (isDigitalPressed(BoardConfig::ACTIVE.input.confirm)) state |= (1 << BTN_CONFIRM);
   }
 
-  if (isDigitalPressed(BoardConfig::ACTIVE.input.left))
-    state |= (1 << BTN_LEFT);
-  if (isDigitalPressed(BoardConfig::ACTIVE.input.right))
-    state |= (1 << BTN_RIGHT);
-  if (isDigitalPressed(BoardConfig::ACTIVE.input.up))
-    state |= (1 << BTN_UP);
-  if (isDigitalPressed(BoardConfig::ACTIVE.input.down))
-    state |= (1 << BTN_DOWN);
+  if (isDigitalPressed(BoardConfig::ACTIVE.input.left)) state |= (1 << BTN_LEFT);
+  if (isDigitalPressed(BoardConfig::ACTIVE.input.right)) state |= (1 << BTN_RIGHT);
+  if (isDigitalPressed(BoardConfig::ACTIVE.input.up)) state |= (1 << BTN_UP);
+  if (isDigitalPressed(BoardConfig::ACTIVE.input.down)) state |= (1 << BTN_DOWN);
   if (isDigitalPressed(BoardConfig::ACTIVE.input.power) &&
-      BoardConfig::ACTIVE.inputStyle !=
-          BoardConfig::InputStyle::DigitalConfirmBackHold &&
-      BoardConfig::ACTIVE.inputStyle !=
-          BoardConfig::InputStyle::DigitalConfirmPowerHold) {
+      BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::DigitalConfirmBackHold &&
+      BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::DigitalConfirmPowerHold) {
     state |= (1 << BTN_POWER);
   }
 
   return state;
 }
 
-void InputManager::applyStateChange(const uint8_t state,
-                                    const unsigned long currentTime) {
+void InputManager::applyStateChange(const uint8_t state, const unsigned long currentTime) {
   pressedEvents = state & ~currentState;
   releasedEvents = currentState & ~state;
 
@@ -338,14 +310,12 @@ void InputManager::updateConfirmBackHold(const unsigned long currentTime) {
 }
 
 void InputManager::updateConfirmPowerHold(const unsigned long currentTime) {
-  const int8_t sharedPin = BoardConfig::ACTIVE.input.confirm >= 0
-                               ? BoardConfig::ACTIVE.input.confirm
-                               : BoardConfig::ACTIVE.input.power;
+  const int8_t sharedPin =
+      BoardConfig::ACTIVE.input.confirm >= 0 ? BoardConfig::ACTIVE.input.confirm : BoardConfig::ACTIVE.input.power;
   const bool pressed = isDigitalPressed(sharedPin);
   uint8_t nonSharedState = getDigitalState();
   nonSharedState |= serviceTouch();
-  if (s_buttonHook)
-    nonSharedState |= s_buttonHook();
+  if (s_buttonHook) nonSharedState |= s_buttonHook();
   bool emitConfirmClick = false;
 
   if (pressed && !confirmPowerPhysicalPressed) {
@@ -357,8 +327,7 @@ void InputManager::updateConfirmPowerHold(const unsigned long currentTime) {
   uint8_t nextState = nonSharedState;
   if (pressed && s_sharedConfirmPowerShortPressEmitsPower) {
     nextState |= (1 << BTN_POWER);
-  } else if (pressed &&
-             currentTime - confirmPowerPressStart >= CONFIRM_POWER_HOLD_MS) {
+  } else if (pressed && currentTime - confirmPowerPressStart >= CONFIRM_POWER_HOLD_MS) {
     confirmPowerLongPressActive = true;
     nextState |= (1 << BTN_POWER);
   }
@@ -443,21 +412,18 @@ void InputManager::update() {
 
   pressedEvents = 0;
   releasedEvents = 0;
-  touchPressedEvent =
-      false; // one-shot touch coord events, cleared each update()
+  touchPressedEvent = false;  // one-shot touch coord events, cleared each update()
   touchReleasedEvent = false;
   touchLongPressEvent = false;
   touchHomeKeyEvent = false;
   touchHomeKeyTapEvent = false;
   touchHomeKeyLongEvent = false;
 
-  if (BoardConfig::ACTIVE.inputStyle ==
-      BoardConfig::InputStyle::DigitalConfirmBackHold) {
+  if (BoardConfig::ACTIVE.inputStyle == BoardConfig::InputStyle::DigitalConfirmBackHold) {
     updateConfirmBackHold(currentTime);
     return;
   }
-  if (BoardConfig::ACTIVE.inputStyle ==
-      BoardConfig::InputStyle::DigitalConfirmPowerHold) {
+  if (BoardConfig::ACTIVE.inputStyle == BoardConfig::InputStyle::DigitalConfirmPowerHold) {
     updateConfirmPowerHold(currentTime);
     return;
   }
@@ -481,19 +447,13 @@ void InputManager::update() {
   }
 }
 
-bool InputManager::isPressed(const uint8_t buttonIndex) const {
-  return currentState & (1 << buttonIndex);
-}
+bool InputManager::isPressed(const uint8_t buttonIndex) const { return currentState & (1 << buttonIndex); }
 
-bool InputManager::wasPressed(const uint8_t buttonIndex) const {
-  return pressedEvents & (1 << buttonIndex);
-}
+bool InputManager::wasPressed(const uint8_t buttonIndex) const { return pressedEvents & (1 << buttonIndex); }
 
 bool InputManager::wasAnyPressed() const { return pressedEvents > 0; }
 
-bool InputManager::wasReleased(const uint8_t buttonIndex) const {
-  return releasedEvents & (1 << buttonIndex);
-}
+bool InputManager::wasReleased(const uint8_t buttonIndex) const { return releasedEvents & (1 << buttonIndex); }
 
 bool InputManager::wasAnyReleased() const { return releasedEvents > 0; }
 
@@ -514,7 +474,7 @@ unsigned long InputManager::getPowerButtonHeldTime() const {
   return powerButtonPressFinish - powerButtonPressStart;
 }
 
-const char *InputManager::getButtonName(const uint8_t buttonIndex) {
+const char* InputManager::getButtonName(const uint8_t buttonIndex) {
   if (buttonIndex <= BTN_POWER) {
     return BUTTON_NAMES[buttonIndex];
   }
@@ -541,40 +501,30 @@ bool InputManager::hasTouch() const {
 #if FREEINK_CAP_TOUCH
   return touchDataEnabled;
 #else
-  return false; // touch code not compiled in (FREEINK_CAP_TOUCH=0)
+  return false;  // touch code not compiled in (FREEINK_CAP_TOUCH=0)
 #endif
 }
 
-InputManager::TouchPoint InputManager::getTouchPoint() const {
-  return touchPoint;
-}
+InputManager::TouchPoint InputManager::getTouchPoint() const { return touchPoint; }
 bool InputManager::isTouchPressed() const { return touchPressed; }
 bool InputManager::wasTouchPressed() const { return touchPressedEvent; }
-bool InputManager::wasTouchReleased() const {
-  return touchReleasedEvent && !touchSuppressed;
-}
+bool InputManager::wasTouchReleased() const { return touchReleasedEvent && !touchSuppressed; }
 
-bool InputManager::wasTouchTap(float &nx, float &ny) const {
+bool InputManager::wasTouchTap(float& nx, float& ny) const {
 #if FREEINK_CAP_TOUCH
-  if (!touchReleasedEvent || touchSuppressed)
-    return false;
+  if (!touchReleasedEvent || touchSuppressed) return false;
   // Hold/long-press detection uses the tighter 28 px stationary slop, but a
   // released tap remains valid until motion reaches the 60 px swipe threshold.
   // Using the stationary threshold here created a 29..59 px dead band where a
   // normal finger roll was neither a tap nor a swipe.
-  if (touchMovedBeyondTapReleaseSlop)
-    return false;
+  if (touchMovedBeyondTapReleaseSlop) return false;
   // Tap position = the FIRST contact sample (touch-down), not the last: the
   // reported centroid drifts 10-20px as a finger rolls off during lift, which
   // made small targets (steppers) feel unreliable with release-point routing.
   // A tap routes to where the user touched, not where the finger let go.
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
   float x = static_cast<float>(touchDownPoint.x) / w;
   float y = static_cast<float>(touchDownPoint.y) / h;
   nx = x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
@@ -587,21 +537,16 @@ bool InputManager::wasTouchTap(float &nx, float &ny) const {
 #endif
 }
 
-bool InputManager::wasTouchPressedAt(float &nx, float &ny) const {
+bool InputManager::wasTouchPressedAt(float& nx, float& ny) const {
 #if FREEINK_CAP_TOUCH
   // Press-edge analogue of wasTouchTap: true on the frame a touch begins,
   // writing the touch-down position normalized 0..1 in the panel's native
   // frame. Lets the app highlight what's under the finger on touch-down (before
   // release).
-  if (!touchPressedEvent)
-    return false;
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
+  if (!touchPressedEvent) return false;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
   float x = static_cast<float>(touchDownPoint.x) / w;
   float y = static_cast<float>(touchDownPoint.y) / h;
   nx = x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
@@ -614,18 +559,12 @@ bool InputManager::wasTouchPressedAt(float &nx, float &ny) const {
 #endif
 }
 
-bool InputManager::isTouchTapCandidate(float &nx, float &ny,
-                                       unsigned long &heldMs) const {
+bool InputManager::isTouchTapCandidate(float& nx, float& ny, unsigned long& heldMs) const {
 #if FREEINK_CAP_TOUCH
-  if (!touchPressed || touchMovedBeyondTapSlop || touchSuppressed)
-    return false;
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
+  if (!touchPressed || touchMovedBeyondTapSlop || touchSuppressed) return false;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
   float x = static_cast<float>(touchDownPoint.x) / w;
   float y = static_cast<float>(touchDownPoint.y) / h;
   nx = x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
@@ -640,19 +579,14 @@ bool InputManager::isTouchTapCandidate(float &nx, float &ny,
 #endif
 }
 
-bool InputManager::isTouchHeldAt(float &nx, float &ny) const {
+bool InputManager::isTouchHeldAt(float& nx, float& ny) const {
 #if FREEINK_CAP_TOUCH
   // Live drag tracking: the latest contact sample (touchUpPoint is refreshed on
   // every sample while pressed), with no tap-slop gate.
-  if (!touchPressed || touchSuppressed)
-    return false;
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
+  if (!touchPressed || touchSuppressed) return false;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
   float x = static_cast<float>(touchUpPoint.x) / w;
   float y = static_cast<float>(touchUpPoint.y) / h;
   nx = x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
@@ -681,34 +615,22 @@ bool InputManager::wasTouchActivity() const {
 #endif
 }
 
-bool InputManager::wasSwipe(float &nxStart, float &nyStart, float &nxEnd,
-                            float &nyEnd) const {
+bool InputManager::wasSwipe(float& nxStart, float& nyStart, float& nxEnd, float& nyEnd) const {
 #if FREEINK_CAP_TOUCH
-  if (!touchReleasedEvent || touchSuppressed)
-    return false;
+  if (!touchReleasedEvent || touchSuppressed) return false;
   // A flick: travelled past a distance threshold within a time window. Distance
   // is measured in native px; the dominant axis is left to the app (after
   // mapping to its logical frame).
-  if (lastTouchHeldDurationMs > TOUCH_SWIPE_MAX_MS)
-    return false;
-  const int dx =
-      static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
-  const int dy =
-      static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
+  if (lastTouchHeldDurationMs > TOUCH_SWIPE_MAX_MS) return false;
+  const int dx = static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
+  const int dy = static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
   const int adx = absInt(dx);
   const int ady = absInt(dy);
-  if (adx < TOUCH_SWIPE_MIN_PX && ady < TOUCH_SWIPE_MIN_PX)
-    return false;
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
-  auto clamp01 = [](float v) {
-    return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
-  };
+  if (adx < TOUCH_SWIPE_MIN_PX && ady < TOUCH_SWIPE_MIN_PX) return false;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
+  auto clamp01 = [](float v) { return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); };
   nxStart = clamp01(static_cast<float>(touchDownPoint.x) / w);
   nyStart = clamp01(static_cast<float>(touchDownPoint.y) / h);
   nxEnd = clamp01(static_cast<float>(touchUpPoint.x) / w);
@@ -723,18 +645,13 @@ bool InputManager::wasSwipe(float &nxStart, float &nyStart, float &nxEnd,
 #endif
 }
 
-bool InputManager::wasTouchLongPress(float &nx, float &ny) const {
+bool InputManager::wasTouchLongPress(float& nx, float& ny) const {
 #if FREEINK_CAP_TOUCH
-  if (!touchLongPressEvent)
-    return false;
+  if (!touchLongPressEvent) return false;
   // Long-press routes to the touch-down point, same rationale as wasTouchTap.
-  const auto &t = BoardConfig::ACTIVE.touch;
-  const uint16_t w = (t.rawMaxX > t.rawMinX)
-                         ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX)
-                         : 1;
-  const uint16_t h = (t.rawMaxY > t.rawMinY)
-                         ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY)
-                         : 1;
+  const auto& t = BoardConfig::ACTIVE.touch;
+  const uint16_t w = (t.rawMaxX > t.rawMinX) ? static_cast<uint16_t>(t.rawMaxX - t.rawMinX) : 1;
+  const uint16_t h = (t.rawMaxY > t.rawMinY) ? static_cast<uint16_t>(t.rawMaxY - t.rawMinY) : 1;
   float x = static_cast<float>(touchDownPoint.x) / w;
   float y = static_cast<float>(touchDownPoint.y) / h;
   nx = x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
@@ -751,8 +668,7 @@ void InputManager::suppressTouchContact() {
 #if FREEINK_CAP_TOUCH
   // Only meaningful mid-contact (or on its release-edge frame); the latch
   // self-clears in serviceTouch() once the contact is fully over.
-  if (touchPressed || touchReleasedEvent)
-    touchSuppressed = true;
+  if (touchPressed || touchReleasedEvent) touchSuppressed = true;
 #endif
 }
 
@@ -760,13 +676,11 @@ bool InputManager::wasHomeKeyPressed() const { return touchHomeKeyEvent; }
 
 bool InputManager::wasHomeKeyTapped() const { return touchHomeKeyTapEvent; }
 
-bool InputManager::wasHomeKeyLongPressed() const {
-  return touchHomeKeyLongEvent;
-}
+bool InputManager::wasHomeKeyLongPressed() const { return touchHomeKeyLongEvent; }
 
 void InputManager::beginTouch() {
 #if FREEINK_CAP_TOUCH
-  const auto &t = BoardConfig::ACTIVE.touch;
+  const auto& t = BoardConfig::ACTIVE.touch;
   if (t.controller == BoardConfig::TouchController::None) {
     return;
   }
@@ -776,6 +690,10 @@ void InputManager::beginTouch() {
   }
   if (t.controller == BoardConfig::TouchController::Ft5x06) {
     beginFt5x06();
+    return;
+  }
+  if (t.controller == BoardConfig::TouchController::Ft6336u) {
+    beginFt6336u();
     return;
   }
   // CHSC6x: I2C bus only. The IRQ is left unconfigured — it's a brief pulse on
@@ -795,7 +713,7 @@ uint8_t InputManager::serviceTouch() {
     return 0;
   }
   const unsigned long now = millis();
-  const auto &t = BoardConfig::ACTIVE.touch;
+  const auto& t = BoardConfig::ACTIVE.touch;
 
   // Contact bookkeeping shared by all backends. Runs BEFORE the poll so the
   // suppression latch releases on the first fully-idle frame (contact over,
@@ -810,24 +728,23 @@ uint8_t InputManager::serviceTouch() {
     pollGt911(now);
   } else if (t.controller == BoardConfig::TouchController::Ft5x06) {
     pollFt5x06(now);
+  } else if (t.controller == BoardConfig::TouchController::Ft6336u) {
+    pollFt6336u(now);
   } else {
-    updateTouchFromIrq(now, 0); // detection polls I2C; the IRQ is unused now
+    updateTouchFromIrq(now, 0);  // detection polls I2C; the IRQ is unused now
     // Synthesized confirm tracks an actually-detected press, not the IRQ line.
-    if (touchPressedEvent)
-      touchIrqPulseUntil = now + TOUCH_IRQ_PULSE_MS;
+    if (touchPressedEvent) touchIrqPulseUntil = now + TOUCH_IRQ_PULSE_MS;
   }
 
   // Long-press classification, beside the tap/swipe machinery it shares state
   // with. Fires once per contact, while the finger is still down.
-  if (touchPressed && !touchMovedBeyondTapSlop && !touchLongPressFired &&
-      !touchSuppressed &&
+  if (touchPressed && !touchMovedBeyondTapSlop && !touchLongPressFired && !touchSuppressed &&
       now - touchDownPoint.timestamp >= TOUCH_LONG_PRESS_MS) {
     touchLongPressFired = true;
     touchLongPressEvent = true;
   }
 
-  return (t.synthesizeConfirm && now < touchIrqPulseUntil) ? (1 << BTN_CONFIRM)
-                                                           : 0;
+  return (t.synthesizeConfirm && now < touchIrqPulseUntil) ? (1 << BTN_CONFIRM) : 0;
 #else
   return 0;
 #endif
@@ -835,8 +752,7 @@ uint8_t InputManager::serviceTouch() {
 
 #if FREEINK_CAP_TOUCH
 
-void InputManager::updateTouchFromIrq(const unsigned long now,
-                                      const int irqRaw) {
+void InputManager::updateTouchFromIrq(const unsigned long now, const int irqRaw) {
   // Poll the controller over I2C on a fixed cadence, independent of the IRQ.
   // The CHSC6x IRQ is a brief (~24ms) pulse at touch-down, not a level held for
   // the contact, so edge/level-gated reads missed quick taps. readChsc6xPoint
@@ -853,21 +769,18 @@ void InputManager::updateTouchFromIrq(const unsigned long now,
       if (!touchPressed) {
         touchPressed = true;
         touchPressedEvent = true;
-        touchDownPoint = point; // first contact sample, used for tap routing
+        touchDownPoint = point;  // first contact sample, used for tap routing
         touchUpPoint = point;
         touchMovedBeyondTapSlop = false;
         touchMovedBeyondTapReleaseSlop = false;
       } else {
         touchUpPoint = point;
-        const int dx = static_cast<int>(touchUpPoint.x) -
-                       static_cast<int>(touchDownPoint.x);
-        const int dy = static_cast<int>(touchUpPoint.y) -
-                       static_cast<int>(touchDownPoint.y);
+        const int dx = static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
+        const int dy = static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
         if (absInt(dx) > TOUCH_TAP_SLOP_PX || absInt(dy) > TOUCH_TAP_SLOP_PX) {
           touchMovedBeyondTapSlop = true;
         }
-        if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX ||
-            absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
+        if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX || absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
           touchMovedBeyondTapReleaseSlop = true;
         }
       }
@@ -882,7 +795,7 @@ void InputManager::updateTouchFromIrq(const unsigned long now,
   }
 }
 
-bool InputManager::readChsc6xPoint(TouchPoint &point) {
+bool InputManager::readChsc6xPoint(TouchPoint& point) {
   const uint8_t addr = BoardConfig::ACTIVE.touch.i2cAddress;
   Wire.beginTransmission(addr);
   Wire.write(TOUCH_READ_COMMAND);
@@ -891,11 +804,9 @@ bool InputManager::readChsc6xPoint(TouchPoint &point) {
   }
 
   uint8_t data[TOUCH_FRAME_SIZE] = {};
-  const uint8_t received =
-      Wire.requestFrom(addr, TOUCH_FRAME_SIZE, static_cast<uint8_t>(true));
+  const uint8_t received = Wire.requestFrom(addr, TOUCH_FRAME_SIZE, static_cast<uint8_t>(true));
   if (received != TOUCH_FRAME_SIZE) {
-    while (Wire.available())
-      Wire.read();
+    while (Wire.available()) Wire.read();
     return false;
   }
   for (uint8_t i = 0; i < TOUCH_FRAME_SIZE; ++i) {
@@ -904,8 +815,7 @@ bool InputManager::readChsc6xPoint(TouchPoint &point) {
   return decodeChsc6xFrame(data, TOUCH_FRAME_SIZE, point);
 }
 
-bool InputManager::decodeChsc6xFrame(const uint8_t *data, const size_t len,
-                                     TouchPoint &point) const {
+bool InputManager::decodeChsc6xFrame(const uint8_t* data, const size_t len, TouchPoint& point) const {
   if (len < 7) {
     return false;
   }
@@ -918,13 +828,12 @@ bool InputManager::decodeChsc6xFrame(const uint8_t *data, const size_t len,
   if ((data[3] & 0x80) == 0) {
     return false;
   }
-  const uint16_t rawX = data[4]; // X: one byte
-  const uint16_t rawY =
-      (static_cast<uint16_t>(data[5]) << 8) | data[6]; // Y: 16-bit big-endian
+  const uint16_t rawX = data[4];                                          // X: one byte
+  const uint16_t rawY = (static_cast<uint16_t>(data[5]) << 8) | data[6];  // Y: 16-bit big-endian
   if ((rawX == 0 && rawY == 0) || (rawX == 0xff && rawY == 0xffff)) {
     return false;
   }
-  const auto &t = BoardConfig::ACTIVE.touch;
+  const auto& t = BoardConfig::ACTIVE.touch;
   point.valid = true;
   // Panel-native coordinates (the calibrated raw range, in the touch panel's
   // own orientation); the app maps to its display/logical frame. See the touch
@@ -935,13 +844,10 @@ bool InputManager::decodeChsc6xFrame(const uint8_t *data, const size_t len,
   return true;
 }
 
-uint16_t InputManager::mapTouchAxis(uint16_t raw, const uint16_t rawMin,
-                                    const uint16_t rawMax,
+uint16_t InputManager::mapTouchAxis(uint16_t raw, const uint16_t rawMin, const uint16_t rawMax,
                                     const uint16_t outMax) const {
-  if (raw <= rawMin)
-    return 0;
-  if (raw >= rawMax)
-    return outMax;
+  if (raw <= rawMin) return 0;
+  if (raw >= rawMax) return outMax;
   return static_cast<uint32_t>(raw - rawMin) * outMax / (rawMax - rawMin);
 }
 
@@ -955,8 +861,7 @@ bool InputManager::ft5x06WriteReg(const uint8_t reg, const uint8_t value) {
   return Wire.endTransmission() == 0;
 }
 
-bool InputManager::ft5x06ReadReg(const uint8_t reg, uint8_t* buf,
-                                 const uint8_t len) {
+bool InputManager::ft5x06ReadReg(const uint8_t reg, uint8_t* buf, const uint8_t len) {
   const uint8_t addr = BoardConfig::ACTIVE.touch.i2cAddress;
   Wire.beginTransmission(addr);
   Wire.write(reg);
@@ -1014,8 +919,7 @@ void InputManager::beginFt5x06() {
   uint16_t ioeMode = 0xFFFF, ioeOut = 0xFFFF;
   freeink::m5ioe1::readReg16(freeink::m5ioe1::REG_GPIO_MODE_L, &ioeMode);
   freeink::m5ioe1::readReg16(freeink::m5ioe1::REG_GPIO_OUT_L, &ioeOut);
-  touchDebugPrintf("[touch] IOE1 addr=0x%02X mode=0x%04X out=0x%04X\n",
-                   freeink::m5ioe1::g_addr, ioeMode, ioeOut);
+  touchDebugPrintf("[touch] IOE1 addr=0x%02X mode=0x%04X out=0x%04X\n", freeink::m5ioe1::g_addr, ioeMode, ioeOut);
   // Full bus scan with the touch rail up: expected residents are 0x32 (RX8130
   // RTC), 0x4F/0x6F (IOE1), 0x68 (BMI270), 0x6E (PM1), 0x50 (NFC on Pro) —
   // whatever ELSE ACKs is the touch controller (FT6336 = 0x38; some unit
@@ -1028,9 +932,10 @@ void InputManager::beginFt5x06() {
   }
   touchDebugPrintf("\n");
 #endif
-  touchDebugPrintf("[touch] FT5x06 probe: enabled=%d wrMode=%d rdId=%d wrIrq=%d "
-                   "cipher=0x%02X fw=0x%02X vendor=0x%02X irq=%d\n",
-                   touchDataEnabled, wrMode, rdId, wrIrq, id[0], id[3], id[5], t.irq);
+  touchDebugPrintf(
+      "[touch] FT5x06 probe: enabled=%d wrMode=%d rdId=%d wrIrq=%d "
+      "cipher=0x%02X fw=0x%02X vendor=0x%02X irq=%d\n",
+      touchDataEnabled, wrMode, rdId, wrIrq, id[0], id[3], id[5], t.irq);
 #endif
 }
 
@@ -1087,10 +992,8 @@ void InputManager::pollFt5x06(const unsigned long now) {
   const uint16_t sy = t.swapXY ? rawX : rawY;
 
   touchPoint.valid = true;
-  touchPoint.x = mapTouchAxis(sx, t.rawMinX, t.rawMaxX,
-                              t.rawMaxX - t.rawMinX);
-  touchPoint.y = mapTouchAxis(sy, t.rawMinY, t.rawMaxY,
-                              t.rawMaxY - t.rawMinY);
+  touchPoint.x = mapTouchAxis(sx, t.rawMinX, t.rawMaxX, t.rawMaxX - t.rawMinX);
+  touchPoint.y = mapTouchAxis(sy, t.rawMinY, t.rawMaxY, t.rawMaxY - t.rawMinY);
   if (t.flipX) {
     touchPoint.x = static_cast<uint16_t>((t.rawMaxX - t.rawMinX) - touchPoint.x);
   }
@@ -1107,20 +1010,16 @@ void InputManager::pollFt5x06(const unsigned long now) {
     touchMovedBeyondTapSlop = false;
     touchMovedBeyondTapReleaseSlop = false;
 #ifdef TOUCH_PROBE_DEBUG
-    touchDebugPrintf("[touch] FT press raw=(%u,%u) panel=(%u,%u)\n", rawX,
-                     rawY, touchPoint.x, touchPoint.y);
+    touchDebugPrintf("[touch] FT press raw=(%u,%u) panel=(%u,%u)\n", rawX, rawY, touchPoint.x, touchPoint.y);
 #endif
   } else {
     touchUpPoint = touchPoint;
-    const int dx = static_cast<int>(touchUpPoint.x) -
-                   static_cast<int>(touchDownPoint.x);
-    const int dy = static_cast<int>(touchUpPoint.y) -
-                   static_cast<int>(touchDownPoint.y);
+    const int dx = static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
+    const int dy = static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
     if (absInt(dx) > TOUCH_TAP_SLOP_PX || absInt(dy) > TOUCH_TAP_SLOP_PX) {
       touchMovedBeyondTapSlop = true;
     }
-    if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX ||
-        absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
+    if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX || absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
       touchMovedBeyondTapReleaseSlop = true;
     }
   }
@@ -1129,7 +1028,7 @@ void InputManager::pollFt5x06(const unsigned long now) {
 // --- GT911 (LilyGo) ---------------------------------------------------------
 
 void InputManager::beginGt911() {
-  const auto &t = BoardConfig::ACTIVE.touch;
+  const auto& t = BoardConfig::ACTIVE.touch;
 
   // Power the touch rail first (boards that gate it, e.g. Sticky's TOUCH_EN on
   // GPIO42). Active-high + settle, before the reset dance and I2C probe;
@@ -1152,8 +1051,7 @@ void InputManager::beginGt911() {
   }
 
   auto resetWithIntLevel = [&](const uint8_t level) {
-    if (t.reset < 0 || t.irq < 0)
-      return;
+    if (t.reset < 0 || t.irq < 0) return;
     pinMode(t.irq, OUTPUT);
     pinMode(t.reset, OUTPUT);
     digitalWrite(t.reset, LOW);
@@ -1170,8 +1068,7 @@ void InputManager::beginGt911() {
   auto probeCandidates = [&]() {
     const uint8_t candidates[2] = {t.i2cAddress, t.i2cAddressAlt};
     for (uint8_t a : candidates) {
-      if (a == 0)
-        continue;
+      if (a == 0) continue;
       Wire.beginTransmission(a);
       if (Wire.endTransmission() == 0) {
         gt911Addr = a;
@@ -1194,26 +1091,23 @@ void InputManager::beginGt911() {
 
   touchDataEnabled = (gt911Addr != 0);
 #ifdef TOUCH_PROBE_DEBUG
-  touchDebugPrintf("[touch] GT911 probe: addr=0x%02X enabled=%d (sda=%d scl=%d "
-                   "cand=0x%02X/0x%02X)\n",
-                   gt911Addr, touchDataEnabled, t.sda, t.scl, t.i2cAddress,
-                   t.i2cAddressAlt);
+  touchDebugPrintf(
+      "[touch] GT911 probe: addr=0x%02X enabled=%d (sda=%d scl=%d "
+      "cand=0x%02X/0x%02X)\n",
+      gt911Addr, touchDataEnabled, t.sda, t.scl, t.i2cAddress, t.i2cAddressAlt);
 #endif
 }
 
-bool InputManager::gt911ReadReg(const uint16_t reg, uint8_t *buf,
-                                const uint8_t len) {
+bool InputManager::gt911ReadReg(const uint16_t reg, uint8_t* buf, const uint8_t len) {
   Wire.beginTransmission(gt911Addr);
   Wire.write(static_cast<uint8_t>(reg >> 8));
   Wire.write(static_cast<uint8_t>(reg & 0xFF));
   if (Wire.endTransmission(false) != 0) {
     return false;
   }
-  const uint8_t got =
-      Wire.requestFrom(gt911Addr, len, static_cast<uint8_t>(true));
+  const uint8_t got = Wire.requestFrom(gt911Addr, len, static_cast<uint8_t>(true));
   if (got != len) {
-    while (Wire.available())
-      Wire.read();
+    while (Wire.available()) Wire.read();
     return false;
   }
   for (uint8_t i = 0; i < len; ++i) {
@@ -1230,6 +1124,249 @@ void InputManager::gt911ClearStatus() {
   Wire.endTransmission();
 }
 
+#if FREEINK_DEVICE_MURPHY_M4
+// The M4 uses the ESP-IDF I2C master driver on controller 1. Keeping this bus
+// separate from Arduino Wire mirrors the factory firmware and avoids conflicts
+// with other SDK-managed buses.
+namespace {
+i2c_master_bus_handle_t gM4TouchBus = nullptr;
+i2c_master_dev_handle_t gM4TouchDevice = nullptr;
+
+static bool m4NativeWriteReg(const uint8_t reg, const uint8_t value) {
+  if (gM4TouchDevice == nullptr) return false;
+  const uint8_t payload[] = {reg, value};
+  const esp_err_t err = i2c_master_transmit(gM4TouchDevice, payload, sizeof(payload), 20);
+  if (err != ESP_OK) {
+    esp_rom_printf("[touch] M4 write reg=%02X value=%02X failed: %s (%d)\r\n", reg, value, esp_err_to_name(err),
+                   static_cast<int>(err));
+  }
+  return err == ESP_OK;
+}
+
+static bool m4NativeRead(const uint8_t reg, uint8_t* buf, const size_t len) {
+  if (gM4TouchDevice == nullptr) return false;
+  const esp_err_t err = i2c_master_transmit_receive(gM4TouchDevice, &reg, 1, buf, len, 20);
+  if (err != ESP_OK) {
+    esp_rom_printf("[touch] M4 read reg=%02X len=%u failed: %s (%d)\r\n", reg, static_cast<unsigned>(len),
+                   esp_err_to_name(err), static_cast<int>(err));
+  }
+  return err == ESP_OK;
+}
+
+static bool m4NativeBegin(const int sda, const int scl, const uint8_t address) {
+  if (gM4TouchDevice != nullptr) return true;
+  i2c_master_bus_config_t busConfig = {};
+  busConfig.i2c_port = I2C_NUM_1;
+  busConfig.sda_io_num = static_cast<gpio_num_t>(sda);
+  busConfig.scl_io_num = static_cast<gpio_num_t>(scl);
+  busConfig.clk_source = I2C_CLK_SRC_DEFAULT;
+  busConfig.glitch_ignore_cnt = 7;
+  busConfig.flags.enable_internal_pullup = 1;
+  esp_err_t err = i2c_new_master_bus(&busConfig, &gM4TouchBus);
+  if (err != ESP_OK) {
+    esp_rom_printf("[touch] M4 i2c_new_master_bus failed: %s\r\n", esp_err_to_name(err));
+    return false;
+  }
+  i2c_device_config_t deviceConfig = {};
+  deviceConfig.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+  deviceConfig.device_address = address;
+  deviceConfig.scl_speed_hz = 100000;
+  err = i2c_master_bus_add_device(gM4TouchBus, &deviceConfig, &gM4TouchDevice);
+  if (err != ESP_OK) {
+    esp_rom_printf("[touch] M4 i2c_master_bus_add_device failed: %s\r\n", esp_err_to_name(err));
+    i2c_del_master_bus(gM4TouchBus);
+    gM4TouchBus = nullptr;
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+#endif  // FREEINK_DEVICE_MURPHY_M4
+
+void InputManager::beginFt6336u() {
+  const auto& t = BoardConfig::ACTIVE.touch;
+
+  if (t.powerEnable >= 0) {
+    gpio_hold_dis(static_cast<gpio_num_t>(t.powerEnable));
+    pinMode(t.powerEnable, OUTPUT);
+#if FREEINK_DEVICE_MURPHY_M4
+    // Murphy Reader v1.2.16 powers the rail and allows 500 ms to settle.
+    // This is runtime-only; no touch firmware/update commands are issued.
+    digitalWrite(t.powerEnable, t.powerEnableActiveHigh ? HIGH : LOW);
+    delay(500);
+#else
+    digitalWrite(t.powerEnable, t.powerEnableActiveHigh ? HIGH : LOW);
+    delay(300);
+#endif
+  }
+
+  if (t.sda >= 0 && t.scl >= 0) {
+#if !FREEINK_DEVICE_MURPHY_M4
+    Wire.begin(t.sda, t.scl, 400000);
+    Wire.setTimeOut(10);
+#endif
+  }
+
+#if FREEINK_DEVICE_MURPHY_M4
+  if (t.sda >= 0 && t.scl >= 0) {
+    // Exact Murphy Reader reset timing: RESET low 50 ms, high 100 ms.
+    // GPIO7 is shared with the display reset line on this board.
+    if (t.reset >= 0) {
+      pinMode(t.reset, OUTPUT);
+      digitalWrite(t.reset, LOW);
+      delay(50);
+      digitalWrite(t.reset, HIGH);
+      delay(100);
+    }
+    if (t.irq >= 0) {
+      pinMode(t.irq, INPUT_PULLUP);
+    }
+    const bool busOk = m4NativeBegin(t.sda, t.scl, t.i2cAddress);
+    const bool initModeOk = busOk && m4NativeWriteReg(0x00, 0x00);
+    const bool initThresholdOk = busOk && m4NativeWriteReg(0x80, 0x16);
+    const bool initRateOk = busOk && m4NativeWriteReg(0x88, 0x04);
+    esp_rom_printf("[touch] M4 OEM volatile init: mode=%d threshold=%d rate=%d\r\n", static_cast<int>(initModeOk),
+                   static_cast<int>(initThresholdOk), static_cast<int>(initRateOk));
+    // Murphy Reader reads the FT6336 status/point block at register 0x02.
+    uint8_t probeFrame[11] = {};
+    touchDataEnabled = busOk && m4NativeRead(0x02, probeFrame, sizeof(probeFrame));
+    esp_rom_printf("[touch] M4 FT6336U ready=%d (SDA=%d SCL=%d address=0x%02X)\r\n", static_cast<int>(touchDataEnabled),
+                   t.sda, t.scl, t.i2cAddress);
+  }
+#else
+  // Probe with retries in case the controller is still stabilising.
+  for (int attempt = 0; attempt < 3 && !touchDataEnabled; ++attempt) {
+    if (attempt > 0) delay(100);
+    Wire.beginTransmission(t.i2cAddress);
+    touchDataEnabled = (Wire.endTransmission() == 0);
+  }
+#endif
+}
+
+// FT6336U register layout (read from reg 0x00, 7 bytes):
+//   [0] device mode, [1] gesture ID, [2] touch point count
+//   [3] P1 xH: event_flag[7:6], reserved[5:4], x[11:8]
+//   [4] P1 xL: x[7:0]
+//   [5] P1 yH: touch_id[7:4], y[11:8]
+//   [6] P1 yL: y[7:0]
+// event_flag: 0=press, 1=lift, 2=contact, 3=reserved. A count>0 with flag!=1 = touching.
+void InputManager::pollFt6336u(const unsigned long now) {
+  if (!touchDataEnabled) return;
+
+#if FREEINK_DEVICE_MURPHY_M4
+  // The FT6336U asserts INT low when a fresh sample is ready. Continue polling
+  // while pressed so the release frame is consumed even if INT rises first.
+  const int irq = BoardConfig::ACTIVE.touch.irq;
+  if (irq >= 0 && digitalRead(irq) != LOW && !touchPressed) return;
+#endif
+
+  if (now < touchReadAt) return;
+  touchReadAt = now + TOUCH_SAMPLE_DELAY_MS;
+
+  uint8_t data[16] = {};
+  bool gotData = false;
+#if FREEINK_DEVICE_MURPHY_M4
+  uint8_t nativeFrame[11] = {};
+  gotData = m4NativeRead(0x02, nativeFrame, sizeof(nativeFrame));
+  if (gotData) {
+    // Convert register-0x02 layout to the canonical FT6336 layout consumed below.
+    data[2] = nativeFrame[0];
+    data[3] = nativeFrame[1];
+    data[4] = nativeFrame[2];
+    data[5] = nativeFrame[3];
+    data[6] = nativeFrame[4];
+  }
+#else
+  const uint8_t addr = BoardConfig::ACTIVE.touch.i2cAddress;
+  Wire.beginTransmission(addr);
+  Wire.write(static_cast<uint8_t>(0x00));
+  if (Wire.endTransmission(false) == 0) {
+    const uint8_t got = Wire.requestFrom(addr, static_cast<uint8_t>(7), static_cast<uint8_t>(true));
+    if (got == 7) {
+      for (uint8_t i = 0; i < 7; ++i) data[i] = Wire.read();
+      gotData = true;
+    } else {
+      while (Wire.available()) Wire.read();
+    }
+  }
+#endif
+
+#ifdef TOUCH_PROBE_DEBUG
+  if (gotData) {
+    const int intPin = BoardConfig::ACTIVE.touch.irq;
+    const int intState = (intPin >= 0) ? digitalRead(intPin) : -1;
+    touchDebugPrintf("[touch] FT6336U poll ok int=%d mode=%02X gest=%02X cnt=%d ev=%d raw=[%02X %02X %02X %02X]\r\n",
+                     intState, data[0], data[1], data[2] & 0x0F, (data[3] >> 6) & 0x03, data[3], data[4], data[5],
+                     data[6]);
+  } else {
+    static uint32_t failCount = 0;
+    if (++failCount % 200 == 1) {
+      touchDebugPrintf("[touch] FT6336U poll fail (total=%lu)\r\n", static_cast<unsigned long>(failCount));
+    }
+  }
+#endif
+  if (!gotData) return;
+  // Reject garbage frames. Pattern A: all four bytes identical (0xE6/E7/E2/01/03).
+  // Pattern B: last three bytes identical but first differs (e.g. 07 03 03 03) —
+  // produces rawX=1795 or rawY=771 which are impossibly out of range and generate
+  // phantom touches at the corner of the screen.
+  const bool uniformGarbage =
+      (data[3] == data[4] && data[3] == data[5] && data[3] == data[6]) || (data[4] == data[5] && data[4] == data[6]);
+  const int oneCount = (data[3] == 0x01) + (data[4] == 0x01) + (data[5] == 0x01) + (data[6] == 0x01);
+  const bool stuckOneGarbage = data[0] == 0x01 && data[1] == 0x01 && (data[2] & 0x0F) == 0x01 && oneCount >= 3;
+  if (uniformGarbage || stuckOneGarbage) {
+    // Do not let a one-byte glitch latch the input loop into continuous reads.
+    if (touchPressed && BoardConfig::ACTIVE.touch.irq >= 0 && digitalRead(BoardConfig::ACTIVE.touch.irq) != 0) {
+      touchPressed = false;
+      touchPoint.valid = false;
+    }
+    return;
+  }
+
+  const uint8_t numPoints = data[2] & 0x0F;
+  const uint8_t eventFlag = (data[3] >> 6) & 0x03;  // 0=down, 1=up, 2=contact
+  const bool isTouching = (numPoints > 0) && (eventFlag != 1);
+
+  if (isTouching) {
+    const uint16_t rawX = (static_cast<uint16_t>(data[3] & 0x0F) << 8) | data[4];
+    const uint16_t rawY = (static_cast<uint16_t>(data[5] & 0x0F) << 8) | data[6];
+    const auto& t = BoardConfig::ACTIVE.touch;
+    const uint16_t sx = t.swapXY ? rawY : rawX;
+    const uint16_t sy = t.swapXY ? rawX : rawY;
+    // BoardConfig ranges describe the post-swap panel axes. Validate after the
+    // mounting transform; validating rawY against rawMaxY rejected the lower
+    // 320 rows of the portrait sensor.
+    if (sx > static_cast<uint16_t>(t.rawMaxX) || sy > static_cast<uint16_t>(t.rawMaxY)) return;
+    touchPoint.valid = true;
+    touchPoint.x = mapTouchAxis(sx, t.rawMinX, t.rawMaxX, t.rawMaxX - t.rawMinX);
+    touchPoint.y = mapTouchAxis(sy, t.rawMinY, t.rawMaxY, t.rawMaxY - t.rawMinY);
+    if (t.flipX) touchPoint.x = static_cast<uint16_t>((t.rawMaxX - t.rawMinX) - touchPoint.x);
+    if (t.flipY) touchPoint.y = static_cast<uint16_t>((t.rawMaxY - t.rawMinY) - touchPoint.y);
+    touchPoint.timestamp = now;
+    if (!touchPressed) {
+      touchPressedEvent = true;
+      touchDownPoint = touchPoint;
+      touchMovedBeyondTapSlop = false;
+    }
+    touchUpPoint = touchPoint;
+    const int dx = static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
+    const int dy = static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
+    if (absInt(dx) > TOUCH_TAP_SLOP_PX || absInt(dy) > TOUCH_TAP_SLOP_PX) {
+      touchMovedBeyondTapSlop = true;
+    }
+    touchPressed = true;
+  } else {
+    if (touchPressed) {
+      touchReleasedEvent = true;
+      lastTouchHeldDurationMs = now - touchDownPoint.timestamp;
+      touchUpPoint = touchPoint;
+    }
+    touchPressed = false;
+    touchPoint.valid = false;
+  }
+}
+
 void InputManager::pollGt911(const unsigned long now) {
   if (gt911Addr == 0) {
     return;
@@ -1244,26 +1381,24 @@ void InputManager::pollGt911(const unsigned long now) {
   // hold stops producing new-data frames (0x80 stays clear), so gating the hold
   // timer on fresh frames would never let it cross the threshold. The
   // press/release EDGES still come from fresh frames (handled after the gate).
-  if (touchHomeKeyDown && !touchHomeKeyLongFired &&
-      now - touchHomeKeyDownAt >= HOME_KEY_LONG_PRESS_MS) {
-    touchHomeKeyLongEvent = true; // crossed the threshold (a hold shortcut)
-    touchHomeKeyLongFired =
-        true; // once per hold; also suppresses the release tap
+  if (touchHomeKeyDown && !touchHomeKeyLongFired && now - touchHomeKeyDownAt >= HOME_KEY_LONG_PRESS_MS) {
+    touchHomeKeyLongEvent = true;  // crossed the threshold (a hold shortcut)
+    touchHomeKeyLongFired = true;  // once per hold; also suppresses the release tap
   }
 
-  if (!(status & 0x80)) { // buffer not ready
+  if (!(status & 0x80)) {  // buffer not ready
     return;
   }
 
   // Home-key press/release edges (need a fresh frame). Short tap = primary
   // "home" action, fires on release; the long hold above suppresses it.
   const bool homeKeyDown = (status & 0x10) != 0;
-  if (homeKeyDown && !touchHomeKeyDown) { // press edge
+  if (homeKeyDown && !touchHomeKeyDown) {  // press edge
     touchHomeKeyEvent = true;
     touchHomeKeyDownAt = now;
     touchHomeKeyLongFired = false;
   } else if (!homeKeyDown && touchHomeKeyDown && !touchHomeKeyLongFired) {
-    touchHomeKeyTapEvent = true; // release edge of a short press
+    touchHomeKeyTapEvent = true;  // release edge of a short press
   }
   touchHomeKeyDown = homeKeyDown;
 
@@ -1274,11 +1409,9 @@ void InputManager::pollGt911(const unsigned long now) {
       // Coordinate bytes start at 0 (no track-id, e.g. M5Paper) or 1 (datasheet
       // standard, e.g. LilyGo) depending on the board's GT911 config.
       const uint8_t o = BoardConfig::ACTIVE.touch.gt911CoordsAtByte0 ? 0 : 1;
-      const uint16_t rawX = static_cast<uint16_t>(pt[o]) |
-                            (static_cast<uint16_t>(pt[o + 1]) << 8);
-      const uint16_t rawY = static_cast<uint16_t>(pt[o + 2]) |
-                            (static_cast<uint16_t>(pt[o + 3]) << 8);
-      const auto &t = BoardConfig::ACTIVE.touch;
+      const uint16_t rawX = static_cast<uint16_t>(pt[o]) | (static_cast<uint16_t>(pt[o + 1]) << 8);
+      const uint16_t rawY = static_cast<uint16_t>(pt[o + 2]) | (static_cast<uint16_t>(pt[o + 3]) << 8);
+      const auto& t = BoardConfig::ACTIVE.touch;
       touchPoint.valid = true;
       // Panel-native coordinates (calibrated raw range, touch panel's
       // orientation); the app maps to its display/logical frame. Correct
@@ -1287,42 +1420,33 @@ void InputManager::pollGt911(const unsigned long now) {
       // 90° sensor), then map with the panel-axis ranges, then per-axis flip.
       const uint16_t sx = t.swapXY ? rawY : rawX;
       const uint16_t sy = t.swapXY ? rawX : rawY;
-      touchPoint.x =
-          mapTouchAxis(sx, t.rawMinX, t.rawMaxX, t.rawMaxX - t.rawMinX);
-      touchPoint.y =
-          mapTouchAxis(sy, t.rawMinY, t.rawMaxY, t.rawMaxY - t.rawMinY);
-      if (t.flipX)
-        touchPoint.x =
-            static_cast<uint16_t>((t.rawMaxX - t.rawMinX) - touchPoint.x);
-      if (t.flipY)
-        touchPoint.y =
-            static_cast<uint16_t>((t.rawMaxY - t.rawMinY) - touchPoint.y);
+      touchPoint.x = mapTouchAxis(sx, t.rawMinX, t.rawMaxX, t.rawMaxX - t.rawMinX);
+      touchPoint.y = mapTouchAxis(sy, t.rawMinY, t.rawMaxY, t.rawMaxY - t.rawMinY);
+      if (t.flipX) touchPoint.x = static_cast<uint16_t>((t.rawMaxX - t.rawMinX) - touchPoint.x);
+      if (t.flipY) touchPoint.y = static_cast<uint16_t>((t.rawMaxY - t.rawMinY) - touchPoint.y);
       touchPoint.timestamp = now;
       if (!touchPressed) {
         touchPressedEvent = true;
-        touchDownPoint = touchPoint; // first contact sample, used for tap
-                                     // routing (wasTouchTap)
+        touchDownPoint = touchPoint;  // first contact sample, used for tap
+                                      // routing (wasTouchTap)
         touchMovedBeyondTapSlop = false;
         touchMovedBeyondTapReleaseSlop = false;
       }
       touchUpPoint = touchPoint;
-      const int dx =
-          static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
-      const int dy =
-          static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
+      const int dx = static_cast<int>(touchUpPoint.x) - static_cast<int>(touchDownPoint.x);
+      const int dy = static_cast<int>(touchUpPoint.y) - static_cast<int>(touchDownPoint.y);
       if (absInt(dx) > TOUCH_TAP_SLOP_PX || absInt(dy) > TOUCH_TAP_SLOP_PX) {
         touchMovedBeyondTapSlop = true;
       }
-      if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX ||
-          absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
+      if (absInt(dx) > TOUCH_TAP_RELEASE_SLOP_PX || absInt(dy) > TOUCH_TAP_RELEASE_SLOP_PX) {
         touchMovedBeyondTapReleaseSlop = true;
       }
 #ifdef TOUCH_PROBE_DEBUG
       if (!touchPressed)
-        touchDebugPrintf("[touch] press pt=[%02X %02X %02X %02X %02X %02X %02X "
-                         "%02X] raw=(%u,%u) mapped=(%u,%u)\n",
-                         pt[0], pt[1], pt[2], pt[3], pt[4], pt[5], pt[6], pt[7],
-                         rawX, rawY, touchPoint.x, touchPoint.y);
+        touchDebugPrintf(
+            "[touch] press pt=[%02X %02X %02X %02X %02X %02X %02X "
+            "%02X] raw=(%u,%u) mapped=(%u,%u)\n",
+            pt[0], pt[1], pt[2], pt[3], pt[4], pt[5], pt[6], pt[7], rawX, rawY, touchPoint.x, touchPoint.y);
 #endif
       touchPressed = true;
     }
@@ -1330,13 +1454,13 @@ void InputManager::pollGt911(const unsigned long now) {
     if (touchPressed) {
       touchReleasedEvent = true;
       lastTouchHeldDurationMs = now - touchDownPoint.timestamp;
-      touchUpPoint = touchPoint; // last contact sample, used for swipe routing
+      touchUpPoint = touchPoint;  // last contact sample, used for swipe routing
     }
     touchPressed = false;
     touchPoint.valid = false;
   }
 
-  gt911ClearStatus(); // GT911 requires clearing 0x814E after each read
+  gt911ClearStatus();  // GT911 requires clearing 0x814E after each read
 }
 
-#endif // FREEINK_CAP_TOUCH
+#endif  // FREEINK_CAP_TOUCH


### PR DESCRIPTION
## Summary

Add a hardware profile and supporting drivers for the Murphy M4 ESP32-S3 e-reader.

## Changes

- add the Murphy M4 board profile, pin mapping, display configuration, SDMMC setup, battery ADC calibration, and dual-channel frontlight configuration
- add the factory-compatible FT6336U runtime initialization and touch-report reader
- add the M4 two-button input mode and coordinate mapping
- support granular brightness and warm/cool frontlight control
- preserve existing board profiles, including the recently added Paper Mono paths

## Touch-controller safety

The implementation does **not** contain or update touch-controller firmware. It only performs the volatile runtime initialization observed in the factory application (`0x00=0x00`, `0x80=0x16`, `0x88=0x04`) and reads touch reports from I2C address `0x2e`. No controller bootloader, erase, flash-write, or upgrade command is used.

## Hardware validation

Tested on a retail Murphy M4:

- display refresh and orientation
- FT6336U touch input and coordinate mapping
- three physical side buttons
- SD card access over SDMMC
- battery percentage and charging behavior
- cool/warm frontlight, including low brightness levels
- sleep and wake behavior
- complete factory-image restoration after testing

## Verification

- `pio run -e murphy_m4` in the matching CrossPoint integration: passed
- `pio check -e murphy_m4 --fail-on-defect low --fail-on-defect medium --fail-on-defect high`: no defects
- CrossPoint existing `default` target: passed

The companion CrossPoint application PR will reference this PR and its resulting SDK commit.

AI tools were used during investigation, implementation, and review. All hardware behavior listed above was validated on the physical device.
