### PR TITLE
Fix render races in InteractionBuffer and shared ThemeTokens

### DIFF
--- a/libs/ui/FreeInkUI/include/FreeInkApp.h
+++ b/libs/ui/FreeInkUI/include/FreeInkApp.h
@@ -10,6 +10,7 @@
 
 #include <FreeInkUI.h>
 
+#include <atomic>
 #include <memory>
 #include <new>
 
@@ -574,24 +575,38 @@ public:
 
   // Copy mode: the app keeps its own (heap-owned) tokens.
   void setTheme(const ThemeTokens &theme) {
-    sharedTheme_ = nullptr;
+    sharedThemeRef_ = nullptr;
     if (ownedTheme_) {
       *ownedTheme_ = theme;
     } else {
       ownedTheme_.reset(new (std::nothrow) ThemeTokens(theme));
     }
   }
-  // Shared mode: dereference caller-owned tokens (they must outlive the app).
-  // Tokens are usually identical for every screen of an app, so sharing one
-  // instance saves the ~1.5KB per-app copy setTheme() keeps — on small heaps
-  // that copy per live screen is the cost that matters. Passing nullptr
-  // reverts to the owned/default tokens.
-  void setThemeRef(const ThemeTokens *theme) {
-    sharedTheme_ = theme;
-    if (theme) ownedTheme_.reset();
+  // Shared mode: dereference caller-owned tokens through a caller-owned
+  // atomic cell (both must outlive the app). Tokens are usually identical
+  // for every screen of an app, so sharing one instance saves the ~1.5KB
+  // per-app copy setTheme() keeps — on small heaps that copy per live screen
+  // is the cost that matters. Passing nullptr reverts to the owned/default
+  // tokens.
+  //
+  // The indirection (a pointer to an atomic pointer, not a plain pointer) is
+  // deliberate: a caller can atomically swap which ThemeTokens instance the
+  // cell points at (write a new one into a fresh, not-currently-referenced
+  // instance, then one atomic store) so every app sharing that cell picks up
+  // the change on its next theme() call without ever dereferencing an
+  // instance that's mid-overwrite. Overwriting a single shared ThemeTokens
+  // in place instead (the old setThemeRef(const ThemeTokens*) contract) let
+  // a render task reading theme().rowHeight/etc. field-by-field observe a
+  // torn mix of old and new fields if a theme change landed mid-read.
+  void setThemeRef(const std::atomic<const ThemeTokens *> *themeRef) {
+    sharedThemeRef_ = themeRef;
+    if (themeRef) ownedTheme_.reset();
   }
   const ThemeTokens &theme() const {
-    if (sharedTheme_) return *sharedTheme_;
+    if (sharedThemeRef_) {
+      const ThemeTokens *t = sharedThemeRef_->load(std::memory_order_acquire);
+      if (t) return *t;
+    }
     if (ownedTheme_) return *ownedTheme_;
     return FALLBACK_THEME_TOKENS;  // owned-copy allocation failed
   }
@@ -675,12 +690,18 @@ public:
     if (clearBeforePaint_)
       target_.fill(device_.screen(), clearPaint_);
 
+    // Build into whichever interaction-table generation isn't currently
+    // published, so route() below (possibly running on another task right
+    // now) never reads one mid-rebuild — see InteractionBuffer's
+    // beginPublishCycle()/publish().
+    interactions_.beginPublishCycle();
     Frame<MaxInteractions> frame(target_, device_, input, interactions_,
                                  assets_);
     ScreenType screen(frame, theme());
     if (screen_)
       screen_(screen, screenUser_);
     lastEvent_ = frame.finish();
+    interactions_.publish();
     if (lastEvent_) {
       dispatch(lastEvent_);
       invalidate(RefreshHint::Fast);
@@ -706,7 +727,9 @@ public:
   // remaining queued taps route against the old screen — same as taps landing
   // just before a transition).
   ActionEvent route(const InputSnapshot &input) {
-    lastEvent_ = interactions_.route(input);
+    // Reads the last-published table (see render()'s beginPublishCycle()/
+    // publish()), never one a concurrent render is mid-rebuilding.
+    lastEvent_ = interactions_.routePublished(input);
     if (lastEvent_) {
       flashSuppressed_ = false;
       dispatch(lastEvent_);
@@ -756,7 +779,7 @@ private:
   // heap copy (setTheme / the constructor's font-derived default). A pointer
   // pair instead of an inline ThemeTokens member keeps sizeof(FreeInkApp)
   // small — the tokens are ~1.5KB and most apps share one instance.
-  const ThemeTokens *sharedTheme_ = nullptr;
+  const std::atomic<const ThemeTokens *> *sharedThemeRef_ = nullptr;
   std::unique_ptr<ThemeTokens> ownedTheme_;
   AssetResolver *assets_ = nullptr;
   InteractionBuffer<MaxInteractions> interactions_{};

--- a/libs/ui/FreeInkUI/include/FreeInkUICore.h
+++ b/libs/ui/FreeInkUI/include/FreeInkUICore.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <atomic>
+
 namespace freeink {
 namespace ui {
 
@@ -1002,29 +1004,35 @@ public:
   virtual State stateFor(ActionId action, int16_t value, State base) const = 0;
 };
 
+// Storage for one generation of hit rects: interactions_/count_/overflowed_.
+// InteractionBuffer below keeps TWO of these (see the cross-task note on
+// building_/published_) so a render task can be constructing a new
+// generation while another task safely reads the last-completed one.
 template <size_t MaxInteractions>
 class InteractionBuffer final : public InteractionSink {
 public:
   bool addInteraction(const Interaction &interaction) override {
     if (interaction.action == NO_ACTION)
       return false;
-    if (count_ >= MaxInteractions) {
-      overflowed_ = true;
+    if (count_[building_] >= MaxInteractions) {
+      overflowed_[building_] = true;
       return false;
     }
-    interactions_[count_++] = interaction;
+    interactions_[building_][count_[building_]++] = interaction;
     return true;
   }
 
   State stateFor(ActionId action, int16_t value, State base) const override {
     State state = base;
-    if (focused_ >= 0 && focused_ < static_cast<int16_t>(count_)) {
-      const Interaction &focused = interactions_[focused_];
+    const size_t count = count_[building_];
+    const Interaction *slot = interactions_[building_];
+    if (focused_ >= 0 && focused_ < static_cast<int16_t>(count)) {
+      const Interaction &focused = slot[focused_];
       if (focused.action == action && focused.value == value)
         state |= StateFocused;
     }
-    if (active_ >= 0 && active_ < static_cast<int16_t>(count_)) {
-      const Interaction &active = interactions_[active_];
+    if (active_ >= 0 && active_ < static_cast<int16_t>(count)) {
+      const Interaction &active = slot[active_];
       if (active.action == action && active.value == value)
         state |= StateActive;
     }
@@ -1037,108 +1045,72 @@ public:
   }
 
   void clear() {
-    count_ = 0;
-    overflowed_ = false;
+    count_[building_] = 0;
+    overflowed_[building_] = false;
   }
 
-  size_t count() const { return count_; }
+  size_t count() const { return count_[building_]; }
   // True if a frame registered more interactions than the buffer holds —
   // dropped elements never receive input, so size the template accordingly.
-  bool overflowed() const { return overflowed_; }
-  const Interaction *data() const { return interactions_; }
+  bool overflowed() const { return overflowed_[building_]; }
+  const Interaction *data() const { return interactions_[building_]; }
   int16_t focusedIndex() const { return focused_; }
   void setFocusedIndex(int16_t index) {
-    if (index >= 0 && index < static_cast<int16_t>(count_))
+    if (index >= 0 && index < static_cast<int16_t>(count_[building_]))
       focused_ = index;
     else
       focused_ = -1;
   }
 
   ActionEvent route(const InputSnapshot &input) {
-    ActionEvent event{};
-
-    if (input.touchPressed) {
-      active_ = findTouch(input.touchX, input.touchY, InputTouch);
-    }
-
-    // Grab semantics: a drag stays bound to the element the finger landed on
-    // even when it wanders off the rect, and follows the x position live.
-    if (input.touchHeld && active_ >= 0 &&
-        active_ < static_cast<int16_t>(count_)) {
-      const Interaction &held = interactions_[active_];
-      if (!hasState(held.state, StateDisabled) &&
-          acceptsInput(held.inputMask, InputDrag)) {
-        ActionEvent dragged = eventFor(active_);
-        dragged.dragPermille = dragPermilleFor(held.rect, input.touchX);
-        return dragged;
-      }
-    }
-
-    if (input.touchReleased) {
-      const int16_t idx =
-          findTouch(input.touchX, input.touchY,
-                    input.longPress ? InputLongPress : InputTouch);
-      active_ = -1;
-      if (idx >= 0) {
-        ActionEvent released = eventFor(idx);
-        released.longPress = input.longPress;
-        // A tap on a draggable element is a jump-to-position: carry the spot.
-        if (acceptsInput(interactions_[idx].inputMask, InputDrag)) {
-          released.dragPermille =
-              dragPermilleFor(interactions_[idx].rect, input.touchX);
-        }
-        return released;
-      }
-    }
-
-    if (input.swipeLeft) {
-      const int16_t idx = findFirst(InputSwipeLeft);
-      if (idx >= 0)
-        return eventFor(idx);
-    }
-    if (input.swipeRight) {
-      const int16_t idx = findFirst(InputSwipeRight);
-      if (idx >= 0)
-        return eventFor(idx);
-    }
-    if (input.back) {
-      const int16_t idx = findFirst(InputBack);
-      if (idx >= 0)
-        return eventFor(idx);
-    }
-    if (input.prev) {
-      const int16_t idx = findFirst(InputPrev);
-      if (idx >= 0)
-        return eventFor(idx);
-    }
-    if (input.next) {
-      const int16_t idx = findFirst(InputNext);
-      if (idx >= 0)
-        return eventFor(idx);
-    }
-
-    if (input.focusNext)
-      moveFocus(1);
-    if (input.focusPrev)
-      moveFocus(-1);
-    // Focus indices persist across frames so GPIO navigation survives
-    // re-renders, but a screen change can leave a stale index. Only confirm a
-    // focus target that exists in the current table and accepts confirm input.
-    if (input.confirm && focused_ >= 0 &&
-        focused_ < static_cast<int16_t>(count_)) {
-      const Interaction &focused = interactions_[focused_];
-      if (!hasState(focused.state, StateDisabled) &&
-          acceptsInput(focused.inputMask, InputConfirm)) {
-        return eventFor(focused_);
-      }
-    }
-
-    return event;
+    return routeAgainst(building_, input);
   }
+
+  // Cross-task counterparts of count()/overflowed()/data()/route(): read the
+  // last-published generation (see publish()) instead of building_, which a
+  // concurrent render may be mid-rebuild on another task. A caller that never
+  // opts into publishing (below) never needs these — every method above
+  // keeps behaving exactly as it always has for single-task use.
+  size_t publishedCount() const {
+    return count_[published_.load(std::memory_order_acquire)];
+  }
+  bool publishedOverflowed() const {
+    return overflowed_[published_.load(std::memory_order_acquire)];
+  }
+  const Interaction *publishedData() const {
+    return interactions_[published_.load(std::memory_order_acquire)];
+  }
+  ActionEvent routePublished(const InputSnapshot &input) {
+    return routeAgainst(published_.load(std::memory_order_acquire), input);
+  }
+
+  // Opts a render pass into cross-task double buffering: subsequent
+  // clear()/addInteraction()/route()/etc. build into whichever generation is
+  // NOT currently published, so a concurrent routePublished()/publishedData()
+  // call on another task never sees a half-rebuilt table. Call once, before
+  // constructing the Frame for this pass. Callers that never call this (every
+  // existing single-task use, including the host test suite) keep building_
+  // pinned at generation 0 forever — a no-op, so this is pure opt-in.
+  void beginPublishCycle() {
+    building_ = static_cast<uint8_t>(1 - published_.load(std::memory_order_relaxed));
+  }
+
+  // Atomically publishes the generation just built (building_) so
+  // routePublished()/publishedData()/publishedCount()/publishedOverflowed()
+  // on any task see a complete, stable table — never one mid-rebuild. Call
+  // once the frame's hit() calls are done (after Frame::finish(), or directly
+  // after building for a caller that doesn't need finish()'s same-generation
+  // route()). Release-paired with the acquire loads above: every write this
+  // generation's addInteraction() calls made is visible to whoever observes
+  // the new published_ value.
+  void publish() { published_.store(building_, std::memory_order_release); }
 
   // Index of the interaction currently under a held touch (-1 when none).
   // Lets the render loop repaint for touch-down feedback: the active element
-  // draws with its StateActive style while the finger is down.
+  // draws with its StateActive style while the finger is down. Shared across
+  // both generations by design — it names an action/value pair, not a raw
+  // index into a specific generation's array — same for focusedIndex() and
+  // the flash state below.
   int16_t activeIndex() const { return active_; }
 
   // Tap flash: mark one action/value for the frame(s) that follow a
@@ -1153,13 +1125,25 @@ public:
   void clearFlash() { flashAction_ = NO_ACTION; }
 
 private:
-  Interaction interactions_[MaxInteractions]{};
-  size_t count_ = 0;
+  // Two generations of hit rects; building_ picks which one clear()/
+  // addInteraction()/route()/etc. currently target, published_ picks which
+  // one routePublished()/publishedData()/etc. read. A caller that never calls
+  // beginPublishCycle()/publish() only ever touches generation 0 through
+  // both, so this is behaviourally identical to the single-buffer design
+  // unless a caller opts in.
+  Interaction interactions_[2][MaxInteractions]{};
+  size_t count_[2] = {0, 0};
+  bool overflowed_[2] = {false, false};
+  uint8_t building_ = 0;
+  std::atomic<uint8_t> published_{0};
+  // Persistent interaction-session state: deliberately NOT per-generation.
+  // focused_ in particular must survive re-renders (GPIO focus navigation),
+  // and both fields are single small values, not a multi-step rebuild, so
+  // they don't have the torn-read hazard count_/interactions_ have.
   int16_t focused_ = -1;
   int16_t active_ = -1;
   ActionId flashAction_ = NO_ACTION; // tap-flash target (see setFlash)
   int16_t flashValue_ = 0;
-  bool overflowed_ = false;
 
   static int16_t dragPermilleFor(const Rect &rect, const int16_t x) {
     if (rect.width <= 1)
@@ -1172,14 +1156,16 @@ private:
     return static_cast<int16_t>(p);
   }
 
-  bool focusable(const Interaction &interaction) const {
+  bool focusable(uint8_t slot, int16_t idx) const {
+    const Interaction &interaction = interactions_[slot][idx];
     return !hasState(interaction.state, StateDisabled) &&
            acceptsInput(interaction.inputMask, InputFocus);
   }
 
-  int16_t findTouch(int16_t x, int16_t y, InputMask kind) const {
-    for (int16_t i = static_cast<int16_t>(count_) - 1; i >= 0; --i) {
-      const Interaction &interaction = interactions_[i];
+  int16_t findTouch(uint8_t slot, int16_t x, int16_t y, InputMask kind) const {
+    const Interaction *interactions = interactions_[slot];
+    for (int16_t i = static_cast<int16_t>(count_[slot]) - 1; i >= 0; --i) {
+      const Interaction &interaction = interactions[i];
       if (hasState(interaction.state, StateDisabled))
         continue;
       const bool acceptsKind = acceptsInput(interaction.inputMask, kind);
@@ -1194,9 +1180,10 @@ private:
     return -1;
   }
 
-  int16_t findFirst(InputMask kind) const {
-    for (int16_t i = 0; i < static_cast<int16_t>(count_); ++i) {
-      const Interaction &interaction = interactions_[i];
+  int16_t findFirst(uint8_t slot, InputMask kind) const {
+    const Interaction *interactions = interactions_[slot];
+    for (int16_t i = 0; i < static_cast<int16_t>(count_[slot]); ++i) {
+      const Interaction &interaction = interactions[i];
       if (hasState(interaction.state, StateDisabled))
         continue;
       if (acceptsInput(interaction.inputMask, kind))
@@ -1205,21 +1192,22 @@ private:
     return -1;
   }
 
-  void moveFocus(int8_t delta) {
-    if (count_ == 0) {
+  void moveFocus(uint8_t slot, int8_t delta) {
+    const size_t count = count_[slot];
+    if (count == 0) {
       focused_ = -1;
       return;
     }
     int16_t start = focused_;
-    if (start < 0 || start >= static_cast<int16_t>(count_))
-      start = delta > 0 ? -1 : static_cast<int16_t>(count_);
-    for (size_t step = 0; step < count_; ++step) {
+    if (start < 0 || start >= static_cast<int16_t>(count))
+      start = delta > 0 ? -1 : static_cast<int16_t>(count);
+    for (size_t step = 0; step < count; ++step) {
       int16_t idx = static_cast<int16_t>(start + delta);
       if (idx < 0)
-        idx = static_cast<int16_t>(count_ - 1);
-      if (idx >= static_cast<int16_t>(count_))
+        idx = static_cast<int16_t>(count - 1);
+      if (idx >= static_cast<int16_t>(count))
         idx = 0;
-      if (focusable(interactions_[idx])) {
+      if (focusable(slot, idx)) {
         focused_ = idx;
         return;
       }
@@ -1228,10 +1216,93 @@ private:
     focused_ = -1;
   }
 
-  ActionEvent eventFor(int16_t idx) const {
-    const Interaction &interaction = interactions_[idx];
+  ActionEvent eventFor(uint8_t slot, int16_t idx) const {
+    const Interaction &interaction = interactions_[slot][idx];
     return ActionEvent{interaction.action, interaction.value,
                        interaction.state};
+  }
+
+  ActionEvent routeAgainst(uint8_t slot, const InputSnapshot &input) {
+    ActionEvent event{};
+    const size_t count = count_[slot];
+
+    if (input.touchPressed) {
+      active_ = findTouch(slot, input.touchX, input.touchY, InputTouch);
+    }
+
+    // Grab semantics: a drag stays bound to the element the finger landed on
+    // even when it wanders off the rect, and follows the x position live.
+    if (input.touchHeld && active_ >= 0 &&
+        active_ < static_cast<int16_t>(count)) {
+      const Interaction &held = interactions_[slot][active_];
+      if (!hasState(held.state, StateDisabled) &&
+          acceptsInput(held.inputMask, InputDrag)) {
+        ActionEvent dragged = eventFor(slot, active_);
+        dragged.dragPermille = dragPermilleFor(held.rect, input.touchX);
+        return dragged;
+      }
+    }
+
+    if (input.touchReleased) {
+      const int16_t idx =
+          findTouch(slot, input.touchX, input.touchY,
+                    input.longPress ? InputLongPress : InputTouch);
+      active_ = -1;
+      if (idx >= 0) {
+        ActionEvent released = eventFor(slot, idx);
+        released.longPress = input.longPress;
+        // A tap on a draggable element is a jump-to-position: carry the spot.
+        if (acceptsInput(interactions_[slot][idx].inputMask, InputDrag)) {
+          released.dragPermille =
+              dragPermilleFor(interactions_[slot][idx].rect, input.touchX);
+        }
+        return released;
+      }
+    }
+
+    if (input.swipeLeft) {
+      const int16_t idx = findFirst(slot, InputSwipeLeft);
+      if (idx >= 0)
+        return eventFor(slot, idx);
+    }
+    if (input.swipeRight) {
+      const int16_t idx = findFirst(slot, InputSwipeRight);
+      if (idx >= 0)
+        return eventFor(slot, idx);
+    }
+    if (input.back) {
+      const int16_t idx = findFirst(slot, InputBack);
+      if (idx >= 0)
+        return eventFor(slot, idx);
+    }
+    if (input.prev) {
+      const int16_t idx = findFirst(slot, InputPrev);
+      if (idx >= 0)
+        return eventFor(slot, idx);
+    }
+    if (input.next) {
+      const int16_t idx = findFirst(slot, InputNext);
+      if (idx >= 0)
+        return eventFor(slot, idx);
+    }
+
+    if (input.focusNext)
+      moveFocus(slot, 1);
+    if (input.focusPrev)
+      moveFocus(slot, -1);
+    // Focus indices persist across frames so GPIO navigation survives
+    // re-renders, but a screen change can leave a stale index. Only confirm a
+    // focus target that exists in the current table and accepts confirm input.
+    if (input.confirm && focused_ >= 0 &&
+        focused_ < static_cast<int16_t>(count)) {
+      const Interaction &focused = interactions_[slot][focused_];
+      if (!hasState(focused.state, StateDisabled) &&
+          acceptsInput(focused.inputMask, InputConfirm)) {
+        return eventFor(slot, focused_);
+      }
+    }
+
+    return event;
   }
 };
 

--- a/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
+++ b/libs/ui/FreeInkUI/include/components/keyboard/keyboard.h
@@ -317,6 +317,14 @@ class TouchHoldRouter {
     explicit operator bool() const { return static_cast<bool>(event); }
   };
 
+  // Reads via routePublished()/publishedData() rather than route()/data():
+  // for a caller that never opts into InteractionBuffer's publish cycle
+  // (beginPublishCycle()/publish()), published_ stays pinned at the same
+  // generation building_ does, so this is behaviourally identical to the
+  // plain route()/data() calls it replaces. For a caller that does opt in
+  // (a render task rebuilding the table on one task while this update() runs
+  // on another), it reads the last complete, published generation instead
+  // of one that may be mid-rebuild.
   template <size_t MaxInteractions>
   Result update(InteractionBuffer<MaxInteractions>& interactions, const bool pressedDown, const int16_t px,
                 const int16_t py, const bool tapped, const int16_t tx, const int16_t ty, const bool inContact,
@@ -335,13 +343,13 @@ class TouchHoldRouter {
         release.touchReleased = true;
         release.touchX = tx;
         release.touchY = ty;
-        result.event = interactions.route(release);
+        result.event = interactions.routePublished(release);
         // Tap slop means the release can land off the pressed key (fingers
         // occlude and slide low on e-paper). A tap is bounded by the slop
         // radius, so dispatching the key the press landed on is what the
         // user meant — a >slop drag is a swipe and never reaches here.
         if (!result.event && heldActive >= 0) {
-          const Interaction& held = interactions.data()[heldActive];
+          const Interaction& held = interactions.publishedData()[heldActive];
           if (!hasState(held.state, StateDisabled) && acceptsInput(held.inputMask, InputTouch)) {
             result.event = ActionEvent{held.action, held.value, held.state};
           }
@@ -361,7 +369,7 @@ class TouchHoldRouter {
       press.touchPressed = true;
       press.touchX = px;
       press.touchY = py;
-      interactions.route(press);
+      interactions.routePublished(press);
       const int16_t active = interactions.activeIndex();
 
       // New contact, or the finger slid onto a different key: restart the
@@ -373,7 +381,8 @@ class TouchHoldRouter {
       }
 
       if (active >= 0) {
-        const uint32_t threshold = interactions.data()[active].value == overrideValue ? overrideHoldMs : holdMs;
+        const uint32_t threshold =
+            interactions.publishedData()[active].value == overrideValue ? overrideHoldMs : holdMs;
         if (nowMs - startMs_ >= threshold) {
           longFired_ = true;
           InputSnapshot release{};
@@ -381,7 +390,7 @@ class TouchHoldRouter {
           release.longPress = true;
           release.touchX = px;
           release.touchY = py;
-          result.event = interactions.route(release);
+          result.event = interactions.routePublished(release);
         }
       }
       return result;
@@ -396,7 +405,7 @@ class TouchHoldRouter {
       longFired_ = false;
       InputSnapshot cancel{};
       cancel.touchReleased = true;
-      interactions.route(cancel);
+      interactions.routePublished(cancel);
       result.activeChanged = true;
     }
     return result;

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -461,6 +461,59 @@ void testEdgeButtonsAndSwipes() {
   CHECK_EQ(buffer.route(input).action, 5);
 }
 
+// Cross-task double-buffer contract (added for the render-task-vs-loop-task
+// interaction table race): publishedCount()/publishedData()/routePublished()
+// must keep reporting the previous generation for as long as a new one is
+// being built via beginPublishCycle()/clear()/addInteraction(), and only
+// switch over atomically once publish() is called -- never a mix of the two.
+// A caller that never opts in must see the exact single-buffer behavior this
+// whole file's other tests rely on.
+void testPublishCycleIsolatesReaders() {
+  InteractionBuffer<8> buffer;
+
+  // Establish a known "old" generation and publish it.
+  buffer.addInteraction(Interaction{Rect{0, 0, 10, 10}, 1, 0, InputTouch, StateNormal, 0});
+  buffer.publish();
+  CHECK_EQ(buffer.publishedCount(), 1u);
+  CHECK_EQ(buffer.publishedData()[0].action, 1);
+
+  // Start building the next generation. A concurrent reader (publishedCount/
+  // publishedData/routePublished) must still see the OLD generation,
+  // untouched, for as long as this isn't published yet.
+  buffer.beginPublishCycle();
+  buffer.clear();
+  buffer.addInteraction(Interaction{Rect{0, 0, 10, 10}, 2, 0, InputTouch, StateNormal, 0});
+  buffer.addInteraction(Interaction{Rect{10, 0, 10, 10}, 3, 0, InputTouch, StateNormal, 0});
+  CHECK_EQ(buffer.publishedCount(), 1u);
+  CHECK_EQ(buffer.publishedData()[0].action, 1);
+  // The generation being built (what Frame uses during layout) already
+  // reflects the new rects.
+  CHECK_EQ(buffer.count(), 2u);
+  CHECK_EQ(buffer.data()[1].action, 3);
+
+  // Publish: readers now atomically see the complete new generation.
+  buffer.publish();
+  CHECK_EQ(buffer.publishedCount(), 2u);
+  CHECK_EQ(buffer.publishedData()[0].action, 2);
+  CHECK_EQ(buffer.publishedData()[1].action, 3);
+
+  InputSnapshot tap;
+  tap.touchReleased = true;
+  tap.touchX = 5;
+  tap.touchY = 5;
+  CHECK_EQ(buffer.routePublished(tap).action, 2);
+
+  // A caller that never calls beginPublishCycle()/publish() at all (every
+  // other test in this file, and every existing single-task consumer) keeps
+  // behaving exactly like the pre-double-buffer design.
+  InteractionBuffer<8> plain;
+  plain.addInteraction(Interaction{Rect{0, 0, 10, 10}, 9, 0, InputTouch, StateNormal, 0});
+  plain.clear();
+  plain.addInteraction(Interaction{Rect{0, 0, 10, 10}, 10, 0, InputTouch, StateNormal, 0});
+  CHECK_EQ(plain.count(), 1u);
+  CHECK_EQ(plain.data()[0].action, 10);
+}
+
 void testListHelpers() {
   CHECK_EQ(listVisibleRows(Rect{0, 0, 100, 360}, 36, 0), 10);
   CHECK_EQ(listVisibleRows(Rect{0, 0, 100, 359}, 36, 0), 9);
@@ -2574,6 +2627,38 @@ void testFreeInkAppHandlerOverflowFlag() {
   CHECK(app.handlerOverflowed());
 }
 
+// setThemeRef() takes a pointer to a caller-owned atomic cell (not a raw
+// ThemeTokens*) so a caller can atomically swap which instance it points at
+// -- every app sharing the cell must pick up the change on its very next
+// theme() call, with no re-call to setThemeRef() needed. This is the
+// property the fix (avoiding an in-place struct overwrite a render task
+// could read mid-write) must preserve.
+void testFreeInkAppSharedThemeRefFollowsAtomicSwap() {
+  FakeDrawTarget draw;
+  DeviceContext device{100, 100};
+  FreeInkApp<4, 1> app(draw, device);
+
+  ThemeTokens tokensA;
+  tokensA.rowHeight = 30;
+  ThemeTokens tokensB;
+  tokensB.rowHeight = 60;
+
+  std::atomic<const ThemeTokens *> themeRef{&tokensA};
+  app.setThemeRef(&themeRef);
+  CHECK_EQ(app.theme().rowHeight, 30);
+
+  // Swap which instance the cell points at (as applySharedUiTheme() does:
+  // build the new tokens into a fresh instance, then one atomic store) --
+  // no second setThemeRef() call.
+  themeRef.store(&tokensB, std::memory_order_release);
+  CHECK_EQ(app.theme().rowHeight, 60);
+
+  // nullptr reverts to the owned/default tokens.
+  app.setThemeRef(nullptr);
+  CHECK(&app.theme() != &tokensA);
+  CHECK(&app.theme() != &tokensB);
+}
+
 // Editor canvas: wrapping, caret-line tracking, scroll helpers, and the render
 // window. FakeDrawTarget is monospace (charWidth 6, lineH 12), so widths are
 // exactly 6*strlen — easy to reason about.
@@ -2648,6 +2733,7 @@ int main() {
   testConfirmIgnoresStaleFocus();
   testConfirmRespectsInputMask();
   testEdgeButtonsAndSwipes();
+  testPublishCycleIsolatesReaders();
   testListHelpers();
   testListVirtualization();
   testListClampsBadTopIndex();
@@ -2698,6 +2784,7 @@ int main() {
   testScreenAnchoredLayout();
   testFreeInkAppDispatchesScreenActions();
   testFreeInkAppHandlerOverflowFlag();
+  testFreeInkAppSharedThemeRefFollowsAtomicSwap();
   testTextArea();
 
   std::printf("%d checks, %d failed\n", checksRun, checksFailed);

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -2202,6 +2202,20 @@ void testTouchHoldRouter() {
   CHECK_EQ(r.event.value, 'q');
   CHECK(!r.event.longPress);
 
+  // A touch-down repaint can start rebuilding the next frame before the
+  // finger releases. The release must continue routing against the complete
+  // published table while that rebuild is in progress; callers should not
+  // disable input between beginPublishCycle() and publish().
+  interactions.publish();
+  r = router.update(interactions, true, 20, 20, false, 0, 0, true, 1200);
+  CHECK(r.activeChanged);
+  interactions.beginPublishCycle();
+  rebuild();
+  r = router.update(interactions, false, 0, 0, true, 20, 20, false, 1300);
+  CHECK_EQ(r.event.value, 'q');
+  CHECK(!r.event.longPress);
+  interactions.publish();
+
   // Hold past the threshold: long-press fires exactly once at threshold and
   // the timer must NOT re-arm on later frames (the repeat bug), and the real
   // release is swallowed.


### PR DESCRIPTION
Two related cross-task races, both from a task rebuilding/overwriting shared state in place while another task could be mid-read of it:

1. InteractionBuffer: the render task's Frame constructor clears and incrementally rebuilds the hit-rect table via addInteraction() during layout; FreeInkApp::route() (loop task, real touch input) or OptionPopup::handleInput() could call route()/data() on the same storage mid-rebuild, reading a torn count_/interactions_ (missed or misrouted taps, not a crash -- reads are bounds-checked against count_ at read time). Documented and worked around elsewhere in the app (KeyboardEntryActivity drops taps during the window instead).

 Fix: InteractionBuffer now holds two generations of hit-rect storage. beginPublishCycle()/publish() are new, purely opt-in methods a caller uses to build into the non-published generation and atomically swap which one publishedCount()/publishedData()/routePublished() read. Every existing method (clear/addInteraction/stateFor/count/data/route) keeps its exact prior behavior for any caller that never opts in -- confirmed against the full host test suite (2643 -> 2659 checks, the same 3 pre-existing, unrelated failures before and after, zero new ones) plus a new test asserting readers see the old generation throughout a build and the new one only after publish().

 FreeInkApp::render() opts in around each Frame; its route() reads via routePublished() instead of route(). Frame is unchanged.

2. ThemeTokens: apps needing the shared theme (UIThemeTokens.h's applySharedUiTheme(), used by every UiAppHost) call setThemeRef() with a pointer to a single static ThemeTokens overwritten in place on every theme refresh (screen entry, live theme change) while another app could be mid-read of the same struct's fields during its own render.

 Fix: setThemeRef() now takes a pointer to a caller-owned std::atomic<const ThemeTokens*> instead of a raw ThemeTokens*. theme() loads it (acquire) on every call. A caller changing themes writes the new ThemeTokens into a fresh instance the cell doesn't yet point at, then does one atomic store (release) -- every app sharing the cell picks up the change on its next theme() call, and nothing ever dereferences an instance mid-overwrite. Preserves the existing "live theme change reaches every referencing app immediately" behavior. New test asserts theme() follows an atomic swap of the cell with no second setThemeRef() call.