### PR TITLE
fix: timeout issues

### DIFF
--- a/libs/network/SecureNet/include/SecureHttpClient.h
+++ b/libs/network/SecureNet/include/SecureHttpClient.h
@@ -413,12 +413,12 @@ class SecureHttpClient {
       } else if (_rootCA) {
         _secure.setCACert(_rootCA);
       }
-      _secure.setTimeout(_timeoutMs / 1000);
+      _secure.setTimeout(_timeoutMs);
       if (!_secure.connect(_host.c_str(), _port)) return false;
       _conn = &_secure;
       _connHttps = true;
     } else {
-      _plain.setTimeout(_timeoutMs / 1000);
+      _plain.setTimeout(_timeoutMs);
       if (!_plain.connect(_host.c_str(), _port)) return false;
       _conn = &_plain;
       _connHttps = false;

--- a/libs/network/SecureNet/include/SecureHttpClient.h
+++ b/libs/network/SecureNet/include/SecureHttpClient.h
@@ -419,6 +419,7 @@ class SecureHttpClient {
       _connHttps = true;
     } else {
       _plain.setTimeout(_timeoutMs);
+      _plain.setConnectionTimeout(_timeoutMs);
       if (!_plain.connect(_host.c_str(), _port)) return false;
       _conn = &_plain;
       _connHttps = false;

--- a/libs/network/SecureNet/src/SecureClient.cpp
+++ b/libs/network/SecureNet/src/SecureClient.cpp
@@ -67,6 +67,8 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
 #endif
   const uint32_t started = millis();
   stop();
+  const uint32_t timeoutMs = getTimeout();
+  _transport.setConnectionTimeout(timeoutMs);
   if (!_transport.connect(host, port)) {
     if (Serial) Serial.printf("[SecureClient] TCP connect failed (%s): %s:%u\n", label, host, port);
     return 0;
@@ -122,7 +124,7 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   // The recv callback is non-blocking (returns WANT_READ when no bytes are
   // buffered), so wolfSSL_connect must be retried across handshake round-trips
   // rather than called once.
-  const uint32_t deadline = millis() + 15000;
+  const uint32_t deadline = millis() + timeoutMs;
   int ret;
   while ((ret = wolfSSL_connect(ssl)) != WOLFSSL_SUCCESS) {
     const int err = wolfSSL_get_error(ssl, ret);


### PR DESCRIPTION
The timeout of TCP connection is incorrectly divided by 1000 (60s to 60ms), this will cause immediate timeout happen on certain special network environments e.g. tun2sock. Also timeout passed to wolfSSL is misconfigured to be a hard-coded 15s not the global timeout 60s.