### PR TITLE
feat: add USB storage and serial transport for X4 pro

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -81,6 +81,10 @@ class SDCardManager {
   // succeeds. The returned pointer implements SdFat's FsBlockDeviceInterface.
   // Do NOT touch the filesystem while the card is handed to the USB host.
   freeink::SdmmcBlockDevice* rawBlockDevice() { return _dev; }
+  // End the FsVolume mount while keeping the native block device alive for a
+  // raw USB-MSC owner. The caller must reinitialize the manager after the
+  // owner releases the card.
+  FsBlockDeviceInterface* detachFilesystemForRawAccess();
 #endif
 
  static SDCardManager& getInstance() { return instance; }

--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -3,6 +3,7 @@
 #include <BoardConfig.h>
 #include <driver/gpio.h>
 #include <SPI.h>
+#include <new>
 
 #include "SdmmcBlockDevice.h"  // no-op unless FREEINK_SD_SDMMC
 
@@ -16,6 +17,8 @@ SDCardManager SDCardManager::instance;
 SDCardManager::SDCardManager() {}
 
 bool SDCardManager::begin() {
+  if (initialized) return true;
+
   // Native SDMMC: SdFat can't drive SDIO, so mount a plain FsVolume on the esp-idf
   // SDMMC block device. FsFile from this volume is the same type the SPI path
   // returns, so the public API and consumers are unchanged.
@@ -29,7 +32,18 @@ bool SDCardManager::begin() {
   // The SD power-enable (sd.powerEnable) is driven by SdmmcBlockDevice itself, which
   // reproduces the OEM's timed HIGH->LOW power-cycle around each mount attempt — do
   // NOT assert it here (holding it HIGH going in breaks that reset sequence).
-  if (!_dev) _dev = new freeink::SdmmcBlockDevice();
+  if (_dev) {
+    // detachFilesystemForRawAccess() intentionally keeps the host and card
+    // alive for USB-MSC. Tear that session down before mounting the volume
+    // again, otherwise sdmmc_host_init() rejects the second initialization.
+    _dev->end();
+  } else {
+    _dev = new (std::nothrow) freeink::SdmmcBlockDevice();
+    if (!_dev) {
+      if (Serial) Serial.printf("[%lu] [SD] SDMMC block-device allocation failed\n", millis());
+      return false;
+    }
+  }
   if (!_dev->begin(BoardConfig::ACTIVE.sdmmc)) {
     if (Serial) Serial.printf("[%lu] [SD] SDMMC init failed\n", millis());
     initialized = false;
@@ -49,6 +63,16 @@ bool SDCardManager::begin() {
   cachedTotalBytes = static_cast<uint64_t>(vol().clusterCount()) * vol().bytesPerCluster();
   cachedUsedBytesValid = false;
   return initialized;
+}
+
+FsBlockDeviceInterface* SDCardManager::detachFilesystemForRawAccess() {
+  if (!initialized || !_dev) return nullptr;
+  _vol.end();
+  initialized = false;
+  cachedTotalBytes = 0;
+  cachedUsedBytes = 0;
+  cachedUsedBytesValid = false;
+  return _dev;
 }
 #else
 SDCardManager::SDCardManager() : sd() {}

--- a/libs/hardware/SDCardManager/src/SdmmcBlockDevice.cpp
+++ b/libs/hardware/SDCardManager/src/SdmmcBlockDevice.cpp
@@ -63,11 +63,13 @@ bool SdmmcBlockDevice::begin(const BoardConfig::SdmmcPins& pins) {
     gpio_hold_dis(static_cast<gpio_num_t>(sdPwr));
     pinMode(sdPwr, OUTPUT);
   }
-  // DMA-capable bounce buffer for the sector-0 validation read. SdFat's own cache may
-  // live in PSRAM / at an unaligned address; a known-good internal-RAM buffer proves
-  // the data path on its own terms.
-  auto* probe = static_cast<uint8_t*>(heap_caps_malloc(512, MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
-  if (!probe) {
+  // Keep one DMA-capable bounce buffer for all block I/O. SdFat's own cache may
+  // live in PSRAM / at an unaligned address, while native SDMMC requires an
+  // internal-RAM DMA buffer. Limiting each transfer to eight sectors keeps the
+  // buffer bounded at 4 KiB and avoids heap churn in the USB-MSC callbacks.
+  _dmaBuffer = static_cast<uint8_t*>(heap_caps_malloc(kSectorSize * kMaxTransferSectors,
+                                                      MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
+  if (!_dmaBuffer) {
     free(card);
     sdmmc_host_deinit();
     return false;
@@ -92,15 +94,15 @@ bool SdmmcBlockDevice::begin(const BoardConfig::SdmmcPins& pins) {
       continue;
     }
     // CSD is valid (capacity known); prove real block I/O before committing.
-    e = sdmmc_read_sectors(card, probe, 0, 1);
+    e = sdmmc_read_sectors(card, _dmaBuffer, 0, 1);
     mountErr = e;
     if (e == ESP_OK) break;
   }
-  heap_caps_free(probe);
-
   if (mountErr != ESP_OK) {
     if (Serial)
       Serial.printf("[%lu] [SD] SDMMC mount failed after retries: %s\n", millis(), esp_err_to_name(mountErr));
+    heap_caps_free(_dmaBuffer);
+    _dmaBuffer = nullptr;
     free(card);
     sdmmc_host_deinit();
     return false;
@@ -115,6 +117,10 @@ void SdmmcBlockDevice::end() {
     _card = nullptr;
     sdmmc_host_deinit();
   }
+  if (_dmaBuffer) {
+    heap_caps_free(_dmaBuffer);
+    _dmaBuffer = nullptr;
+  }
 }
 
 // esp-idf SDMMC uses DMA, which requires the transfer buffer to be in DMA-capable
@@ -122,25 +128,31 @@ void SdmmcBlockDevice::end() {
 // (PSRAM / arbitrary alignment), which makes sdmmc_read/write_sectors fail. Bounce
 // through a DMA-capable buffer. (heap_caps_aligned_alloc via MALLOC_CAP_DMA.)
 bool SdmmcBlockDevice::readSectors(Sector_t sector, uint8_t* dst, size_t ns) {
-  if (!_card) return false;
-  const size_t bytes = ns * 512u;
-  auto* bounce = static_cast<uint8_t*>(heap_caps_malloc(bytes, MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
-  if (!bounce) return false;
-  const esp_err_t e = sdmmc_read_sectors(static_cast<sdmmc_card_t*>(_card), bounce, sector, ns);
-  if (e == ESP_OK) memcpy(dst, bounce, bytes);
-  heap_caps_free(bounce);
-  return e == ESP_OK;
+  if (!_card || !_dmaBuffer || !dst || ns == 0) return false;
+  while (ns > 0) {
+    const size_t count = ns > kMaxTransferSectors ? kMaxTransferSectors : ns;
+    const size_t bytes = count * kSectorSize;
+    if (sdmmc_read_sectors(static_cast<sdmmc_card_t*>(_card), _dmaBuffer, sector, count) != ESP_OK) return false;
+    memcpy(dst, _dmaBuffer, bytes);
+    sector += count;
+    dst += bytes;
+    ns -= count;
+  }
+  return true;
 }
 
 bool SdmmcBlockDevice::writeSectors(Sector_t sector, const uint8_t* src, size_t ns) {
-  if (!_card) return false;
-  const size_t bytes = ns * 512u;
-  auto* bounce = static_cast<uint8_t*>(heap_caps_malloc(bytes, MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
-  if (!bounce) return false;
-  memcpy(bounce, src, bytes);
-  const esp_err_t e = sdmmc_write_sectors(static_cast<sdmmc_card_t*>(_card), bounce, sector, ns);
-  heap_caps_free(bounce);
-  return e == ESP_OK;
+  if (!_card || !_dmaBuffer || !src || ns == 0) return false;
+  while (ns > 0) {
+    const size_t count = ns > kMaxTransferSectors ? kMaxTransferSectors : ns;
+    const size_t bytes = count * kSectorSize;
+    memcpy(_dmaBuffer, src, bytes);
+    if (sdmmc_write_sectors(static_cast<sdmmc_card_t*>(_card), _dmaBuffer, sector, count) != ESP_OK) return false;
+    sector += count;
+    src += bytes;
+    ns -= count;
+  }
+  return true;
 }
 
 Sector_t SdmmcBlockDevice::sectorCount() {

--- a/libs/hardware/SDCardManager/src/SdmmcBlockDevice.h
+++ b/libs/hardware/SDCardManager/src/SdmmcBlockDevice.h
@@ -39,10 +39,14 @@ class SdmmcBlockDevice : public FsBlockDeviceInterface {
   bool syncDevice() override { return true; }
 
  private:
+  static constexpr size_t kSectorSize = 512;
+  static constexpr size_t kMaxTransferSectors = 8;
+
   // esp-idf's sdmmc_card_t is a typedef of an anonymous struct, so it can't be
   // forward-declared here (a `struct sdmmc_card_t;` tag is a different, conflicting
   // type). Hold it opaquely and cast in the .cpp, where the esp-idf header is included.
   void* _card = nullptr;
+  uint8_t* _dmaBuffer = nullptr;
 };
 
 }  // namespace freeink

--- a/libs/hardware/UsbMassStorage/include/UsbMassStorage.h
+++ b/libs/hardware/UsbMassStorage/include/UsbMassStorage.h
@@ -1,59 +1,64 @@
 #pragma once
 
 // USB Mass Storage ("USB Transfer" mode): exposes a block device (the SD card)
-// to a USB host as a removable disk, so the user can copy files over USB without
-// removing the card. Mirrors the Xteink stock firmware, which drives esp-idf's
-// TinyUSB MSC over the same sdmmc_card_t the app FAT-mounts. Here it's built on
-// arduino-esp32's USBMSC class, whose read/write callbacks route straight to the
-// block device's sector I/O.
-//
-// OPT-IN per board via FREEINK_CAP_USB_MSC (see BoardConfig.h) — requires the
-// build's USB stack in OTG mode (ARDUINO_USB_MODE=0 + CONFIG_TINYUSB_MSC_ENABLED).
-// When the capability is off this compiles to a trivial stub and links no USB code.
-//
-// Lifecycle (caller — e.g. a "USB Transfer" UI mode):
-//   1. Ensure the SD card is mounted, then SUSPEND all app filesystem use (the
-//      host owns the card while active — concurrent app writes corrupt the FS).
-//   2. begin(blockDevice). USB enumerates as a disk.
-//   3. Poll hostConnected(): once it drops (host ejected / cable pulled), end()
-//      and re-init the app's filesystem (the stock firmware flushes deferred
-//      writes and remounts here).
+// to a USB host as a removable disk. The owner must suspend all filesystem use
+// before begin() and must reboot/remount after the host ejects or disconnects.
 
 #include <BoardConfig.h>
 
+#include <atomic>
+
+namespace freeink {
+
+enum class UsbMassStorageState : uint8_t {
+  Idle,
+  WaitingForHost,
+  Connected,
+  Accessed,
+  Ejected,
+  Disconnected,
+  IoError,
+};
+
+}  // namespace freeink
+
 #if FREEINK_CAP_USB_MSC
-#include <SdFat.h>  // FsBlockDeviceInterface (requires USE_BLOCK_DEVICE_INTERFACE=1)
+#include <SdFat.h>
 
 namespace freeink {
 
 class UsbMassStorage {
  public:
-  // Expose `dev` (512-byte sectors, count from dev->sectorCount()) over USB-MSC
-  // and start the USB device. Returns false if already active or the card is
-  // absent. The caller must have suspended its own FS use first.
   bool begin(FsBlockDeviceInterface* dev);
-
-  // Stop MSC and tear the USB device down. The caller re-inits its FS after.
   void end();
 
   bool active() const { return _active; }
-
-  // True while a USB host currently has the disk mounted. Transitions to false
-  // on unplug / host eject — the caller's cue to end() and remount the FS.
+  UsbMassStorageState state() const;
   bool hostConnected() const;
 
+  // Called by the TinyUSB callbacks to publish the most recent host event.
+  void markAccessed() const;
+  void markEjected() const;
+  void markIoError() const;
+
  private:
+  // TinyUSB callbacks and the app loop run in separate FreeRTOS tasks on the
+  // S3, so publish lifecycle updates atomically rather than relying on a
+  // best-effort byte-sized write.
+  mutable std::atomic<UsbMassStorageState> _state{UsbMassStorageState::Idle};
+  mutable std::atomic<bool> _hostSeen{false};
   bool _active = false;
 };
 
 }  // namespace freeink
 
-#else  // !FREEINK_CAP_USB_MSC — stub, no USB/TinyUSB code linked
+#else
 
 namespace freeink {
 class UsbMassStorage {
  public:
   bool active() const { return false; }
+  UsbMassStorageState state() const { return UsbMassStorageState::Idle; }
   bool hostConnected() const { return false; }
 };
 }  // namespace freeink

--- a/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
+++ b/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
@@ -6,47 +6,127 @@
 #include <USB.h>
 #include <USBMSC.h>
 
-// TinyUSB device-mounted state. Declared here to avoid pulling the full tusb
-// header set into this TU; it's a plain C symbol from the arduino-esp32 USB stack.
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+
 extern "C" bool tud_mounted(void);
 
 namespace freeink {
 namespace {
 
 USBMSC gMsc;
-FsBlockDeviceInterface* gDev = nullptr;
+std::atomic<UsbMassStorage*> gOwner{nullptr};
+std::atomic<FsBlockDeviceInterface*> gDev{nullptr};
 constexpr uint16_t kBlockSize = 512;
+uint8_t gSectorScratch[kBlockSize];
 
-// USBMSC read/write callbacks. TinyUSB passes a byte `offset` within the LBA for
-// scatter transfers; in practice it is 0 and `bufsize` is a whole number of
-// sectors. Route to the block device's sector I/O (SdmmcBlockDevice already
-// bounces through DMA-capable memory).
+bool isRangeValid(FsBlockDeviceInterface* dev, const uint32_t lba, const uint32_t offset, const uint32_t bufsize) {
+  if (!dev || bufsize == 0) return false;
+  const uint64_t totalBytes = static_cast<uint64_t>(dev->sectorCount()) * kBlockSize;
+  const uint64_t start = static_cast<uint64_t>(lba) * kBlockSize + offset;
+  const uint64_t end = start + bufsize;
+  return end >= start && end <= totalBytes;
+}
+
 int32_t mscRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
-  if (gDev == nullptr || (bufsize % kBlockSize) != 0) return -1;
-  const uint32_t ns = bufsize / kBlockSize;
-  if (!gDev->readSectors(lba + offset / kBlockSize, static_cast<uint8_t*>(buffer), ns)) return -1;
+  auto* const dev = gDev.load();
+  auto* const owner = gOwner.load();
+  if (!buffer || !isRangeValid(dev, lba, offset, bufsize)) {
+    if (owner) owner->markIoError();
+    return -1;
+  }
+
+  const uint64_t start = static_cast<uint64_t>(lba) * kBlockSize + offset;
+  auto* output = static_cast<uint8_t*>(buffer);
+  uint32_t remaining = bufsize;
+  uint64_t cursor = start;
+
+  if ((offset % kBlockSize) == 0 && (bufsize % kBlockSize) == 0) {
+    const size_t sectors = bufsize / kBlockSize;
+    if (!dev->readSectors(static_cast<Sector_t>(start / kBlockSize), output, sectors)) {
+      if (owner) owner->markIoError();
+      return -1;
+    }
+  } else {
+    while (remaining > 0) {
+      const auto sector = static_cast<Sector_t>(cursor / kBlockSize);
+      const size_t within = static_cast<size_t>(cursor % kBlockSize);
+      const size_t count = std::min<size_t>(kBlockSize - within, remaining);
+      if (!dev->readSector(sector, gSectorScratch)) {
+        if (owner) owner->markIoError();
+        return -1;
+      }
+      memcpy(output, gSectorScratch + within, count);
+      output += count;
+      cursor += count;
+      remaining -= count;
+    }
+  }
+
+  if (owner) owner->markAccessed();
   return static_cast<int32_t>(bufsize);
 }
 
 int32_t mscWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
-  if (gDev == nullptr || (bufsize % kBlockSize) != 0) return -1;
-  const uint32_t ns = bufsize / kBlockSize;
-  if (!gDev->writeSectors(lba + offset / kBlockSize, buffer, ns)) return -1;
+  auto* const dev = gDev.load();
+  auto* const owner = gOwner.load();
+  if (!buffer || !isRangeValid(dev, lba, offset, bufsize)) {
+    if (owner) owner->markIoError();
+    return -1;
+  }
+
+  const uint64_t start = static_cast<uint64_t>(lba) * kBlockSize + offset;
+  auto* input = buffer;
+  uint32_t remaining = bufsize;
+  uint64_t cursor = start;
+
+  if ((offset % kBlockSize) == 0 && (bufsize % kBlockSize) == 0) {
+    const size_t sectors = bufsize / kBlockSize;
+    if (!dev->writeSectors(static_cast<Sector_t>(start / kBlockSize), input, sectors)) {
+      if (owner) owner->markIoError();
+      return -1;
+    }
+  } else {
+    while (remaining > 0) {
+      const auto sector = static_cast<Sector_t>(cursor / kBlockSize);
+      const size_t within = static_cast<size_t>(cursor % kBlockSize);
+      const size_t count = std::min<size_t>(kBlockSize - within, remaining);
+      if (!dev->readSector(sector, gSectorScratch)) {
+        if (owner) owner->markIoError();
+        return -1;
+      }
+      memcpy(gSectorScratch + within, input, count);
+      if (!dev->writeSector(sector, gSectorScratch)) {
+        if (owner) owner->markIoError();
+        return -1;
+      }
+      input += count;
+      cursor += count;
+      remaining -= count;
+    }
+  }
+
+  if (owner) owner->markAccessed();
   return static_cast<int32_t>(bufsize);
 }
 
-// Accept host START/STOP UNIT (spin-up/eject) — nothing to gate; the medium is
-// always present while active.
-bool mscStartStop(uint8_t /*power_condition*/, bool /*start*/, bool /*load_eject*/) { return true; }
+bool mscStartStop(uint8_t /*power_condition*/, bool start, bool load_eject) {
+  if (load_eject && !start) {
+    if (auto* const owner = gOwner.load()) owner->markEjected();
+  }
+  return true;
+}
 
 }  // namespace
 
 bool UsbMassStorage::begin(FsBlockDeviceInterface* dev) {
-  if (_active || dev == nullptr) return false;
-  const uint32_t sectors = dev->sectorCount();
-  if (sectors == 0) return false;  // no card / not mounted
+  if (_active || !dev || dev->sectorCount() == 0) return false;
 
-  gDev = dev;
+  gDev.store(dev);
+  gOwner.store(this);
+  _state.store(UsbMassStorageState::WaitingForHost);
+  _hostSeen.store(false);
   gMsc.vendorID("FreeInk");
   gMsc.productID("SD Card");
   gMsc.productRevision("1.0");
@@ -55,11 +135,20 @@ bool UsbMassStorage::begin(FsBlockDeviceInterface* dev) {
   gMsc.onStartStop(mscStartStop);
   gMsc.onRead(mscRead);
   gMsc.onWrite(mscWrite);
-  if (!gMsc.begin(sectors, kBlockSize)) {
-    gDev = nullptr;
+  if (!gMsc.begin(dev->sectorCount(), kBlockSize)) {
+    gMsc.end();
+    gOwner.store(nullptr);
+    gDev.store(nullptr);
+    _state.store(UsbMassStorageState::Idle);
     return false;
   }
-  USB.begin();
+  if (!USB.begin()) {
+    gMsc.end();
+    gOwner.store(nullptr);
+    gDev.store(nullptr);
+    _state.store(UsbMassStorageState::Idle);
+    return false;
+  }
   _active = true;
   return true;
 }
@@ -67,11 +156,43 @@ bool UsbMassStorage::begin(FsBlockDeviceInterface* dev) {
 void UsbMassStorage::end() {
   if (!_active) return;
   gMsc.end();
-  gDev = nullptr;
+  gOwner.store(nullptr);
+  gDev.store(nullptr);
   _active = false;
+  _state.store(UsbMassStorageState::Idle);
+  _hostSeen.store(false);
 }
 
-bool UsbMassStorage::hostConnected() const { return _active && tud_mounted(); }
+UsbMassStorageState UsbMassStorage::state() const {
+  if (!_active) return UsbMassStorageState::Idle;
+  const auto current = _state.load();
+  if (current == UsbMassStorageState::Ejected || current == UsbMassStorageState::IoError) return current;
+
+  if (!tud_mounted()) {
+    return _hostSeen.load() ? UsbMassStorageState::Disconnected : UsbMassStorageState::WaitingForHost;
+  }
+
+  _hostSeen.store(true);
+  auto expected = UsbMassStorageState::WaitingForHost;
+  _state.compare_exchange_strong(expected, UsbMassStorageState::Connected);
+  return _state.load();
+}
+
+bool UsbMassStorage::hostConnected() const {
+  const auto current = state();
+  return current == UsbMassStorageState::Connected || current == UsbMassStorageState::Accessed;
+}
+
+void UsbMassStorage::markAccessed() const {
+  auto current = _state.load();
+  while (current != UsbMassStorageState::Ejected && current != UsbMassStorageState::IoError) {
+    if (_state.compare_exchange_weak(current, UsbMassStorageState::Accessed)) return;
+  }
+}
+
+void UsbMassStorage::markEjected() const { _state.store(UsbMassStorageState::Ejected); }
+
+void UsbMassStorage::markIoError() const { _state.store(UsbMassStorageState::IoError); }
 
 }  // namespace freeink
 


### PR DESCRIPTION
## Summary

- Add X4 Pro USB mass-storage support backed by its native SDMMC card.
- Safely detach the filesystem before handing raw sectors to the USB host, preventing concurrent filesystem and MSC access.
- Use a reusable, bounded 4 KiB DMA-capable buffer for SDMMC transfers rather than allocating during host callbacks.
- Handle partial-sector MSC requests, host eject/disconnect, and I/O errors.
- Fail cleanly if USB initialization cannot start, synchronize USB callback state with the app loop, and support remounting after USB Drive mode exits.

## Additional Context

While USB Drive is active, the host exclusively owns the SD card; the firmware must remount it after the host ejects or disconnects.

The fixed DMA buffer stays in internal DMA-capable RAM and caps each transfer at eight 512-byte sectors. That keeps SDMMC requests safe for native USB without callback-time heap churn.