### PR TITLE
Grow list rows by the measured wrapped lines of label and subtitle

### DIFF
--- a/libs/ui/FreeInkUI/include/components/lists/list.h
+++ b/libs/ui/FreeInkUI/include/components/lists/list.h
@@ -280,16 +280,21 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       cursorY = static_cast<int16_t>(cursorY + headerH + rowGap);
       continue;
     }
-    // Per-item height: a label or subtitle whose style allows wrapping
-    // (maxLines > 1) and that overflows its slot grows the row by exactly its
-    // extra text lines, keeping the vertical padding a single-line row carries.
-    // Every other row keeps the uniform rowH (styles default to maxLines == 1,
-    // so touch-sized rows are unaffected).
+    // Per-item height: text whose style allows wrapping (maxLines > 1) and
+    // that overflows its slot grows the row by exactly the extra lines it
+    // USES — measured, not maxLines: a two-line title in a three-line budget
+    // costs one extra line, not two. In a subtitle row the label band takes
+    // its wrapped lines and the subtitle, which may itself wrap, moves below
+    // them; vertical padding stays what a single-line row carries. Label-only
+    // rows keep the "would maxLines already fit rowH" gate, so touch-sized
+    // rows stay unaffected; a subtitle row's rowH is sized for one label line
+    // by construction, so any wrap grows it.
     int16_t itemH = rowH;
     int16_t subH = 0;
+    uint8_t labelLines = 1;
     const int16_t labelLh = frame.target().lineHeight(props.labelText.font);
-    // Width the wrapped text is laid out in, shared by this sizing pass and the
-    // draw below: the row content minus the leading icon.
+    // Width the wrapped text is laid out in, shared by this sizing pass and
+    // the draw below: the row content minus the leading icon.
     int16_t contentAvail = static_cast<int16_t>(rowArea.width - sidePad * 2);
     if (item.icon || item.iconAsset) {
       const BitmapRef ic =
@@ -300,24 +305,10 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       contentAvail =
           static_cast<int16_t>(contentAvail - iconSize - props.textGap);
     }
-    if (item.subtitle) {
-      // The subtitle owns its own line(s) under the label, spanning the full
-      // content width. A maxLines > 1 subtitle reserves its wrapped height so
-      // the row grows to fit the extra lines; the default single-line case
-      // keeps the old lineHeight fast path and leaves rowH unchanged.
-      const int16_t subLh = frame.target().lineHeight(props.subtitleText.font);
-      subH = props.subtitleText.maxLines > 1
-                 ? measureWrappedText(frame.target(), item.subtitle,
-                                      props.subtitleText, contentAvail)
-                       .height
-                 : subLh;
-      const int16_t basePad = static_cast<int16_t>(rowH - labelLh - subLh);
-      const int16_t needed = static_cast<int16_t>(
-          labelLh + subH + (basePad > 0 ? basePad : 0));
-      if (needed > rowH)
-        itemH = needed;
-    } else if (item.label && props.labelText.maxLines > 1 &&
-               static_cast<int16_t>(labelLh * props.labelText.maxLines) > rowH) {
+    if (item.label && props.labelText.maxLines > 1 &&
+        (item.subtitle != nullptr ||
+         static_cast<int16_t>(labelLh * props.labelText.maxLines) > rowH)) {
+      // The label band also loses the trailing value/toggle slot.
       int16_t labelAvail = contentAvail;
       if (item.toggle) {
         labelAvail = static_cast<int16_t>(
@@ -331,12 +322,39 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
                 .width -
             props.valueInset - props.textGap);
       }
-      if (frame.target()
-              .measureText(props.labelText.font, item.label, props.labelText)
-              .width > labelAvail) {
-        itemH =
-            static_cast<int16_t>(rowH + labelLh * (props.labelText.maxLines - 1));
+      // The cheap single-line width check gates the full wrap layout, so
+      // rows whose label fits pay one measure and nothing else.
+      if (labelAvail > 0 &&
+          frame.target()
+                  .measureText(props.labelText.font, item.label,
+                               props.labelText)
+                  .width > labelAvail) {
+        const Size wrapped = measureWrappedText(
+            frame.target(), item.label, props.labelText, labelAvail);
+        const int16_t lines =
+            labelLh > 0 ? static_cast<int16_t>(wrapped.height / labelLh) : 1;
+        if (lines > 1)
+          labelLines = static_cast<uint8_t>(lines);
       }
+    }
+    if (item.subtitle) {
+      // The subtitle owns its own line(s) under the label, spanning the full
+      // content width. A maxLines > 1 subtitle reserves its wrapped height so
+      // the row grows to fit the extra lines; the default single-line case
+      // keeps the old lineHeight fast path.
+      const int16_t subLh = frame.target().lineHeight(props.subtitleText.font);
+      subH = props.subtitleText.maxLines > 1
+                 ? measureWrappedText(frame.target(), item.subtitle,
+                                      props.subtitleText, contentAvail)
+                       .height
+                 : subLh;
+      const int16_t basePad = static_cast<int16_t>(rowH - labelLh - subLh);
+      const int16_t needed = static_cast<int16_t>(
+          labelLh * labelLines + subH + (basePad > 0 ? basePad : 0));
+      if (needed > rowH)
+        itemH = needed;
+    } else if (labelLines > 1) {
+      itemH = static_cast<int16_t>(rowH + labelLh * (labelLines - 1));
     }
     if (static_cast<int16_t>(cursorY + itemH) > rowArea.bottom() ||
         drawnRows >= visible || i >= end)
@@ -390,13 +408,18 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
     TextStyle labelStyle =
         textStyleWithForeground(props.labelText, style.foreground);
     const int16_t labelH = frame.target().lineHeight(labelStyle.font);
+    // The band holds every label line the height pre-pass measured (usually
+    // one); the subtitle and the row's growth both follow it.
+    const int16_t labelBlockH = static_cast<int16_t>(labelH * labelLines);
+    // subH carries over from the sizing pass: the subtitle's wrapped height,
+    // or its single line height, or 0 without a subtitle.
     Rect band = content;
     if (item.subtitle) {
       int16_t bandTop = static_cast<int16_t>(
-          content.y + (content.height - labelH - subH) / 2);
+          content.y + (content.height - labelBlockH - subH) / 2);
       if (bandTop < content.y)
         bandTop = content.y;
-      band = Rect{content.x, bandTop, content.width, labelH};
+      band = Rect{content.x, bandTop, content.width, labelBlockH};
     }
 
     const BitmapRef icon =
@@ -492,8 +515,8 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       frame.target().text(Rect{band.x, band.y, availW, band.height}, item.label,
                           labelStyle);
       frame.target().text(
-          Rect{content.x, static_cast<int16_t>(band.y + labelH), content.width,
-               subH},
+          Rect{content.x, static_cast<int16_t>(band.y + band.height),
+               content.width, subH},
           item.subtitle,
           textStyleWithForeground(props.subtitleText, style.foreground));
     } else {

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -1413,6 +1413,130 @@ void testListSectionHeaders() {
   CHECK_EQ(secondHeaderY, 130);
 }
 
+void testListWrappedLabelHeights() {
+  // Per-item height: a wrapping label grows its row by the lines it USES,
+  // not by maxLines; a subtitle follows the wrapped label band; and the
+  // "would maxLines already fit rowH" gate still protects touch-sized rows.
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+  InteractionBuffer<16> interactions;
+
+  // 480 wide, sidePadding 10 -> 460px of label width; charWidth 6 fits 7
+  // ten-char words per line, so ten words wrap onto exactly two lines.
+  const char* longLabel =
+      "aaaaaaaaa aaaaaaaaa aaaaaaaaa aaaaaaaaa aaaaaaaaa "
+      "aaaaaaaaa aaaaaaaaa aaaaaaaaa aaaaaaaaa aaaaaaaaa";
+
+  // Label-only, dense e-ink row (20px holds one 12px line): two used lines
+  // out of a three-line budget grow the row by ONE line height (32), not two.
+  {
+    FakeDrawTarget draw;
+    Frame<16> frame(draw, device, input, interactions);
+    ListItem items[2]{};
+    items[0].label = longLabel;
+    items[1].label = "short";
+    ListProps props;
+    props.items = items;
+    props.count = 2;
+    props.rowHeight = 20;
+    props.sidePadding = 10;
+    props.labelText.maxLines = 3;
+    list(frame, Rect{0, 0, 480, 400}, props);
+    int16_t row0H = 0;
+    int16_t row1Y = -1;
+    for (size_t i = 0; i < draw.opCount; ++i) {
+      const FakeDrawTarget::Op& op = draw.ops[i];
+      if (op.kind != FakeDrawTarget::Op::Fill || op.rect.width != 480) continue;
+      if (op.rect.y == 0) row0H = op.rect.height;
+      if (op.rect.y > 0 && row1Y < 0) row1Y = op.rect.y;
+    }
+    CHECK_EQ(row0H, 32);  // 20 + one extra 12px line, not 20 + 24
+    CHECK_EQ(row1Y, 32);  // the next row starts right below the grown one
+  }
+
+  // Label + subtitle: the row grows the same way, the label band holds both
+  // lines, and the subtitle sits under the band instead of under line one.
+  {
+    FakeDrawTarget draw;
+    Frame<16> frame(draw, device, input, interactions);
+    ListItem items[2]{};
+    items[0].label = longLabel;
+    items[0].subtitle = "Author";
+    items[1].label = "short";
+    items[1].subtitle = "Author";
+    ListProps props;
+    props.items = items;
+    props.count = 2;
+    props.rowHeight = 40;
+    props.sidePadding = 10;
+    props.labelText.maxLines = 3;
+    list(frame, Rect{0, 0, 480, 400}, props);
+    int16_t row0H = 0;
+    int16_t row1H = 0;
+    for (size_t i = 0; i < draw.opCount; ++i) {
+      const FakeDrawTarget::Op& op = draw.ops[i];
+      if (op.kind != FakeDrawTarget::Op::Fill || op.rect.width != 480) continue;
+      if (op.rect.y == 0) row0H = op.rect.height;
+      if (op.rect.y == 52) row1H = op.rect.height;
+    }
+    CHECK_EQ(row0H, 52);
+    CHECK_EQ(row1H, 40);  // a fitting label keeps the uniform height
+    // Subtitle of the grown row: band is (52 - 24 - 12) / 2 = 8 from the row
+    // top, so the subtitle's 12px line starts at 8 + 24 = 32.
+    bool subtitleAt32 = false;
+    for (size_t i = 0; i < draw.opCount; ++i) {
+      const FakeDrawTarget::Op& op = draw.ops[i];
+      if (op.kind == FakeDrawTarget::Op::Text && op.rect.y == 32 && op.rect.height == 12) subtitleAt32 = true;
+    }
+    CHECK(subtitleAt32);
+  }
+
+  // Wrapped SUBTITLE: a maxLines > 1 subtitle that overflows grows the row by
+  // its own extra lines while the label keeps one (the complementary case).
+  {
+    FakeDrawTarget draw;
+    Frame<16> frame(draw, device, input, interactions);
+    ListItem items[1]{};
+    items[0].label = "short";
+    items[0].subtitle = longLabel;
+    ListProps props;
+    props.items = items;
+    props.count = 1;
+    props.rowHeight = 40;
+    props.sidePadding = 10;
+    props.subtitleText.maxLines = 2;
+    list(frame, Rect{0, 0, 480, 400}, props);
+    int16_t row0H = 0;
+    for (size_t i = 0; i < draw.opCount; ++i) {
+      const FakeDrawTarget::Op& op = draw.ops[i];
+      if (op.kind == FakeDrawTarget::Op::Fill && op.rect.width == 480 && op.rect.y == 0) row0H = op.rect.height;
+    }
+    CHECK_EQ(row0H, 52);  // 12 label + 24 wrapped subtitle + 16 base padding
+  }
+
+  // Touch-sized gate: without a subtitle, a 44px row already fits two 12px
+  // lines, so a wrapping two-line-budget label does not grow it.
+  {
+    FakeDrawTarget draw;
+    Frame<16> frame(draw, device, input, interactions);
+    ListItem items[1]{};
+    items[0].label = longLabel;
+    ListProps props;
+    props.items = items;
+    props.count = 1;
+    props.rowHeight = 44;
+    props.sidePadding = 10;
+    props.labelText.maxLines = 2;
+    list(frame, Rect{0, 0, 480, 400}, props);
+    int16_t row0H = 0;
+    for (size_t i = 0; i < draw.opCount; ++i) {
+      const FakeDrawTarget::Op& op = draw.ops[i];
+      if (op.kind == FakeDrawTarget::Op::Fill && op.rect.width == 480 && op.rect.y == 0) row0H = op.rect.height;
+    }
+    CHECK_EQ(row0H, 44);
+  }
+}
+
 
 void testCrossInkSleepScreenComposition() {
   // The minimal-stats sleep screen composes from existing pieces: an
@@ -2767,6 +2891,7 @@ int main() {
   testThemePrimitiveParity();
   testRotationAndBitmapSampling();
   testListSectionHeaders();
+  testListWrappedLabelHeights();
   testCrossInkSleepScreenComposition();
   testCoverCarousel();
   testLayoutTextWrapping();


### PR DESCRIPTION
Rebased on main — this now **composes with 58d34b3** (subtitle wrapping) rather than overlapping it:

- **The label above a subtitle can wrap too**: the label band takes its measured lines and the (possibly wrapped) subtitle moves below it. This covers the title-plus-author list shape (an e-reader library shelf), where the LABEL carries the long text — 58d34b3 covered the complementary case where the subtitle does.
- **Measured lines, not the maxLines budget**: label-only rows now grow by the lines the label actually uses — a two-line title in a three-line budget costs one extra line, not two.
- **Host tests for both mechanisms** (neither had any): exact-lines label growth, wrapped-subtitle growth, subtitle placement under the wrapped band, and the touch-size gate.

Running validated on hardware (Xteink X4, CrossInk fork of crosspoint-reader). `test/host/run.sh`: 2669 checks; the only failures are the 3 pre-existing ones on main (battery bolt tests still expecting triangles after 2fea991 switched to a pixel bitmap, plus one Line-op count) — unrelated, happy to fix separately.

No API change; callers that never set `maxLines > 1` are untouched.