### PR TITLE
feat: opt-in fast-DU refresh shortcut for the Xteink X4 Pro

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
@@ -135,6 +135,21 @@ static const Ssd1677Config& ssd1677X4Config() {
 }
 #endif
 
+// Xteink X4 Pro with the fast-DU shortcut — OPT-IN via
+// -DFREEINK_X4PRO_FAST_DU_SHORTCUT. The X4 Pro paints on the stock X4 config
+// (same GDEQ0426T82 panel class — see ssd1677ActiveConfig), so the same
+// ~85 ms/refresh win applies, and so does the same panel-variance caveat: 0x1C
+// skips the per-refresh temperature load and power sequencing, and artifacts
+// tend to appear only over long sessions and across temperature. Enable only
+// after validating on your unit. SSD1677-batch units only — UC8179/UC8279
+// batches select a different driver and never reach this config.
+#ifdef FREEINK_X4PRO_FAST_DU_SHORTCUT
+static const Ssd1677Config& ssd1677X4ProConfig() {
+  static const Ssd1677Config cfg = fastDuRefreshShortcut(ssd1677DefaultConfig());
+  return cfg;
+}
+#endif
+
 Ssd1677Driver::Ssd1677Driver(const Ssd1677Config& cfg)
     : _cfg(cfg),
       _w(BoardConfig::ACTIVE.displayWidth),
@@ -695,7 +710,12 @@ static const Ssd1677Config& ssd1677ActiveConfig() {
     case BoardConfig::Board::Sticky: return ssd1677StickyConfig();
     // X4 Pro runs on the stock X4/GDEQ0426T82 config — same controller and panel
     // class, confirmed painting on hardware. No custom LUT or drive voltages needed.
+    // Layers the fast-DU shortcut only when the build opts in (ssd1677X4ProConfig).
+#ifdef FREEINK_X4PRO_FAST_DU_SHORTCUT
+    case BoardConfig::Board::XteinkX4Pro: return ssd1677X4ProConfig();
+#else
     case BoardConfig::Board::XteinkX4Pro: return ssd1677DefaultConfig();
+#endif
     // X4 layers the fast-DU shortcut on the default only when the build has
     // opted in (see ssd1677X4Config); stock 0xFC parity otherwise.
 #ifdef FREEINK_X4_FAST_DU_SHORTCUT


### PR DESCRIPTION
## Summary

Adds an opt-in `FREEINK_X4PRO_FAST_DU_SHORTCUT` define that gives the Xteink X4 Pro the same differential fast-DU refresh shortcut the X4 already has behind `FREEINK_X4_FAST_DU_SHORTCUT`.

Today `Ssd1677Driver` pins `XteinkX4Pro` to the stock absolute fast sequence (`0xFC`), which reloads temperature and power-cycles the panel on every refresh (~500 ms measured on stock). The `0x1C` differential fast-DU path — already implemented and field-proven on the X4's SSD1677 glass — has no X4 Pro branch. This change adds one: under the define, `ssd1677X4ProConfig()` applies the existing `fastDuRefreshShortcut()` transform for `Board::XteinkX4Pro`, saving roughly ~85 ms per page-turn refresh.

## Gating

- Off by default; without the define the driver is byte-identical to today for every board.
- SSD1677-scoped only: newer X4 Pro batches that detect as UC8179/UC8279 never reach this config and are unaffected.

## Testing

Tested on X4 Pro hardware (SSD1677 batch) over multi-day reading sessions: page turns confirmed visibly faster by the device owner, with a ghosting/darkening soak across long sessions. One early ghosting report during testing was root-caused to an unrelated stale SDK pin in the test harness (missing grayscale fixes already on `main`), not to this shortcut — re-testing on current `main` was clean and the owner reports it working great.

Since fast-DU on this glass class has historically been panel-batch sensitive, keeping it opt-in until it accumulates wider soak coverage seems right; happy to follow up with a default-on change for `XteinkX4Pro` if/when you're comfortable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
