### PR TITLE
fix: drop redundant exists() check in SDCardManager::openFileForRead

### DIFF
--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -293,11 +293,6 @@ bool SDCardManager::ensureDirectoryExists(const char* path) {
 }
 
 bool SDCardManager::openFileForRead(const char* moduleName, const char* path, FsFile& file) {
-  if (!vol().exists(path)) {
-    if (Serial) Serial.printf("[%lu] [%s] File does not exist: %s\n", millis(), moduleName, path);
-    return false;
-  }
-
   file = vol().open(path, O_RDONLY);
   if (!file) {
     if (Serial) Serial.printf("[%lu] [%s] Failed to open file for reading: %s\n", millis(), moduleName, path);


### PR DESCRIPTION
## Summary
- `openFileForRead()` called `vol().exists(path)` and then `vol().open(path, O_RDONLY)` separately. Both independently walk the FAT directory table, and `open()` already fails cleanly (returns an invalid `FsFile`) when the path doesn't exist, so the `exists()` pre-check bought nothing but a doubled directory traversal on every read-open.
- This function is the single universal read-open path in the SDK (all `readFile`/`readFileToStream`/`readFileToBuffer` helpers and every direct caller funnel through it), so the fix benefits any consumer that opens files for reading — image decoding, pixel/data caches, glyph loading, config/metadata reads, etc.

## Test plan
- [x] Build against a board profile that exercises SD reads and confirm files still open correctly (existing file, missing file, and the two `std::string`/`String` overloads which just forward to this function).
- [x] Confirm the "Failed to open file for reading" log message still fires correctly when a path doesn't exist (previously logged as "File does not exist" via the removed branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)