### PR TITLE
feat: add multi-touch rotation gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ polled, raw register reads + the reset/address dance, including the capacitive h
 key), and the **FT5x06 family** (Paper Mono's FT6336 — polled point reads gated on
 the active-low IRQ line). The InputManager exposes `hasTouch/isTouchPressed/wasTouchPressed/
 wasTouchReleased/getTouchPoint`; it delivers coordinates raw-panel-oriented and the
-app owns rotation. The GT911 boards set their `TouchConfig` in the board profile
-(e.g. `BoardConfig::LILYGO_T5_PRO_GT911`).
+app owns display-orientation mapping. GT911 additionally provides allocation-free
+multi-contact snapshots, completed 2-4 finger translation gestures, and completed
+two-finger rotations with a signed angle, center, and duration. The GT911 boards set
+their `TouchConfig` in the board profile (e.g. `BoardConfig::LILYGO_T5_PRO_GT911`).
 
 ## Build composition — devices × capabilities
 

--- a/libs/hardware/InputManager/include/InputManager.h
+++ b/libs/hardware/InputManager/include/InputManager.h
@@ -142,10 +142,16 @@ class InputManager {
   // contacts plus their centroid start/end normalized in its panel-native
   // frame; applications opt into the exact counts they support, map display
   // orientation, and decide whether the result is up/down/left/right. Pinches,
-  // rotations, diagonal motion, delayed gestures, ambiguous contact matching,
-  // track-ID replacements, and sequences above MAX_TOUCH_CONTACTS are rejected.
+  // diagonal motion, delayed gestures, ambiguous contact matching, track-ID
+  // replacements, and sequences above MAX_TOUCH_CONTACTS are rejected.
   bool wasMultiTouchSwipe(uint8_t& contactCount, float& nxStart, float& nyStart, float& nxEnd, float& nyEnd,
                           unsigned long& durationMs) const;
+  // One-shot two-contact rotation on release. Positive degrees are clockwise
+  // and negative degrees counterclockwise in the corrected panel-native frame,
+  // normalized to [-180, 180]. The center is the average of the start/end
+  // contact centroids, normalized to 0..1. Pinches and sub-threshold turns are
+  // rejected, and an accepted rotation cannot also become a translation.
+  bool wasMultiTouchRotation(float& degrees, float& nxCenter, float& nyCenter, unsigned long& durationMs) const;
   // One-shot long-press: fires WHILE the finger is still down, once a
   // stationary contact (within tap slop) has been held TOUCH_LONG_PRESS_MS.
   // Position is the touch-down point, normalized like wasTouchTap. Fires at
@@ -156,8 +162,8 @@ class InputManager {
   // Ignore the remainder of the current contact: tap, swipe, release,
   // tap-candidate and held queries report nothing until the finger lifts and
   // the release edge has passed, then a fresh contact is delivered normally.
-  // Self-clears; async tap, single-swipe, and multi-touch-swipe queues are
-  // gated by the same latch.
+  // Self-clears; async tap, single-swipe, multi-touch-swipe, and rotation
+  // queues are gated by the same latch.
   void suppressTouchContact();
   // True if a touch press or release happened this frame. Coarse "the user
   // touched the screen" signal (the touch analogue of wasAnyPressed/Released)
@@ -226,6 +232,11 @@ class InputManager {
   bool popMultiTouchSwipe(uint8_t& contactCount, float& nxStart, float& nyStart, float& nxEnd, float& nyEnd,
                           unsigned long& durationMs);
 
+  // Pop a queued completed two-contact rotation. Values use the same signed
+  // degrees, normalized center, and duration contract as
+  // wasMultiTouchRotation().
+  bool popMultiTouchRotation(float& degrees, float& nxCenter, float& nyCenter, unsigned long& durationMs);
+
   // --- Diagnostics -----------------------------------------------------------
   // A live sample of one button-group ADC pin: the raw reading plus the BTN_*
   // it currently classifies as (-1 = no band matched). On the Xteink ADC ladder
@@ -260,6 +271,13 @@ class InputManager {
     uint16_t durationMs;
   };
   QueueHandle_t _asyncMultiTouchSwipeQueue = nullptr;
+  struct QueuedMultiTouchRotation {
+    float degrees;
+    uint16_t centerX;
+    uint16_t centerY;
+    uint16_t durationMs;
+  };
+  QueueHandle_t _asyncMultiTouchRotationQueue = nullptr;
   TaskHandle_t _asyncTask = nullptr;
   uint32_t _asyncPollMs = 15;
   static void asyncTaskTrampoline(void* self);
@@ -310,8 +328,10 @@ class InputManager {
   bool findContactAssignment(const TouchSnapshot& snapshot, uint8_t trackedCount,
                              uint8_t assignment[MAX_TOUCH_CONTACTS]) const;
   bool isTrackedContact(const MultiTouchPoint& point) const;
-  bool hasStableMultiTouchGeometry() const;
+  bool hasStableTranslationGeometry() const;
+  bool hasEligibleRotationScale() const;
   bool isMultiTouchTranslation(unsigned long now) const;
+  bool classifyMultiTouchRotation(unsigned long now);
   void normalizeTouchPoint(uint16_t x, uint16_t y, float& nx, float& ny) const;
 
   uint8_t currentState;
@@ -354,7 +374,8 @@ class InputManager {
   MultiTouchGestureState multiTouchGestureState = MultiTouchGestureState::Idle;
   TrackedTouchContact multiTouchContacts[MAX_TOUCH_CONTACTS] = {};
   uint8_t trackedTouchContactCount = 0;
-  bool touchMultiContactSequence = false;  // suppresses single-contact classifiers until full release
+  bool multiTouchRotationEligible = false;  // latched false if any frame leaves the allowed scale band
+  bool touchMultiContactSequence = false;   // suppresses single-contact classifiers until full release
   bool multiTouchSwipeEvent = false;
   uint8_t multiTouchSwipeContactCount = 0;
   uint16_t multiTouchSwipeStartX = 0;
@@ -362,6 +383,11 @@ class InputManager {
   uint16_t multiTouchSwipeEndX = 0;
   uint16_t multiTouchSwipeEndY = 0;
   uint16_t multiTouchSwipeDurationMs = 0;
+  bool multiTouchRotationEvent = false;
+  float multiTouchRotationDegrees = 0.0f;
+  uint16_t multiTouchRotationCenterX = 0;
+  uint16_t multiTouchRotationCenterY = 0;
+  uint16_t multiTouchRotationDurationMs = 0;
   TouchPoint touchDownPoint = {false, 0, 0, 0};  // first sample of the current contact (tap routing)
   TouchPoint touchUpPoint = {false, 0, 0, 0};    // last sample before release (swipe routing)
   unsigned long lastTouchHeldDurationMs = 0;     // contact duration, latched at release

--- a/libs/hardware/InputManager/src/InputManager.cpp
+++ b/libs/hardware/InputManager/src/InputManager.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "MultiTouchGestureMath.h"
+
 #if FREEINK_CAP_TOUCH
 #include <Wire.h>
 #include <driver/gpio.h>
@@ -176,6 +178,7 @@ void InputManager::beginAsync(const uint8_t taskPriority, const uint32_t pollMs,
   _asyncTapQueue = xQueueCreate(queueLen, sizeof(float) * 2);
   _asyncSwipeQueue = xQueueCreate(queueLen, sizeof(float) * 4);
   _asyncMultiTouchSwipeQueue = xQueueCreate(queueLen, sizeof(QueuedMultiTouchSwipe));
+  _asyncMultiTouchRotationQueue = xQueueCreate(queueLen, sizeof(QueuedMultiTouchRotation));
   xTaskCreate(asyncTaskTrampoline, "fi_input", 4096, this, taskPriority, &_asyncTask);
 }
 
@@ -201,6 +204,11 @@ void InputManager::asyncPoll() {
                                                      multiTouchSwipeEndX,         multiTouchSwipeEndY,
                                                      multiTouchSwipeContactCount, multiTouchSwipeDurationMs};
       xQueueSend(_asyncMultiTouchSwipeQueue, &multiTouchSwipe, 0);
+    }
+    if (_asyncMultiTouchRotationQueue && multiTouchRotationEvent && !touchSuppressed) {
+      const QueuedMultiTouchRotation rotation = {multiTouchRotationDegrees, multiTouchRotationCenterX,
+                                                 multiTouchRotationCenterY, multiTouchRotationDurationMs};
+      xQueueSend(_asyncMultiTouchRotationQueue, &rotation, 0);
     }
     vTaskDelay(pdMS_TO_TICKS(_asyncPollMs));
   }
@@ -240,6 +248,16 @@ bool InputManager::popMultiTouchSwipe(uint8_t& contactCount, float& nxStart, flo
   normalizeTouchPoint(swipe.startX, swipe.startY, nxStart, nyStart);
   normalizeTouchPoint(swipe.endX, swipe.endY, nxEnd, nyEnd);
   durationMs = swipe.durationMs;
+  return true;
+}
+
+bool InputManager::popMultiTouchRotation(float& degrees, float& nxCenter, float& nyCenter, unsigned long& durationMs) {
+  if (!_asyncMultiTouchRotationQueue) return false;
+  QueuedMultiTouchRotation rotation{};
+  if (xQueueReceive(_asyncMultiTouchRotationQueue, &rotation, 0) != pdTRUE) return false;
+  degrees = rotation.degrees;
+  normalizeTouchPoint(rotation.centerX, rotation.centerY, nxCenter, nyCenter);
+  durationMs = rotation.durationMs;
   return true;
 }
 
@@ -437,6 +455,7 @@ void InputManager::update() {
   touchReleasedEvent = false;
   touchLongPressEvent = false;
   multiTouchSwipeEvent = false;
+  multiTouchRotationEvent = false;
   touchHomeKeyEvent = false;
   touchHomeKeyTapEvent = false;
   touchHomeKeyLongEvent = false;
@@ -688,6 +707,23 @@ bool InputManager::wasMultiTouchSwipe(uint8_t& contactCount, float& nxStart, flo
 #endif
 }
 
+bool InputManager::wasMultiTouchRotation(float& degrees, float& nxCenter, float& nyCenter,
+                                         unsigned long& durationMs) const {
+#if FREEINK_CAP_TOUCH
+  if (!multiTouchRotationEvent || touchSuppressed) return false;
+  degrees = multiTouchRotationDegrees;
+  normalizeTouchPoint(multiTouchRotationCenterX, multiTouchRotationCenterY, nxCenter, nyCenter);
+  durationMs = multiTouchRotationDurationMs;
+  return true;
+#else
+  (void)degrees;
+  (void)nxCenter;
+  (void)nyCenter;
+  (void)durationMs;
+  return false;
+#endif
+}
+
 bool InputManager::wasTouchLongPress(float& nx, float& ny) const {
 #if FREEINK_CAP_TOUCH
   if (!touchLongPressEvent || touchMultiContactSequence) return false;
@@ -708,6 +744,7 @@ void InputManager::suppressTouchContact() {
   if (touchPressed || touchReleasedEvent) touchSuppressed = true;
   cancelMultiTouchGesture();
   if (_asyncMultiTouchSwipeQueue) xQueueReset(_asyncMultiTouchSwipeQueue);
+  if (_asyncMultiTouchRotationQueue) xQueueReset(_asyncMultiTouchRotationQueue);
 #endif
 }
 
@@ -729,6 +766,7 @@ void InputManager::startMultiTouchGesture(const TouchSnapshot& snapshot, const u
   }
 
   trackedTouchContactCount = snapshot.count;
+  multiTouchRotationEligible = trackedTouchContactCount == 2;
   for (uint8_t i = 0; i < trackedTouchContactCount; ++i) {
     multiTouchContacts[i] = {snapshot.points[i].id, snapshot.points[i].point, snapshot.points[i].point};
     multiTouchContacts[i].start.timestamp = now;
@@ -756,12 +794,14 @@ void InputManager::blockMultiTouchGesture() {
 void InputManager::resetMultiTouchGesture() {
   multiTouchGestureState = MultiTouchGestureState::Idle;
   trackedTouchContactCount = 0;
+  multiTouchRotationEligible = false;
   touchMultiContactSequence = false;
   for (auto& contact : multiTouchContacts) contact = {};
 }
 
 void InputManager::cancelMultiTouchGesture() {
   multiTouchSwipeEvent = false;
+  multiTouchRotationEvent = false;
   multiTouchGestureState =
       (touchPressed || touchReleasedEvent) ? MultiTouchGestureState::Blocked : MultiTouchGestureState::Idle;
 }
@@ -872,7 +912,7 @@ bool InputManager::isTrackedContact(const MultiTouchPoint& point) const {
   return false;
 }
 
-bool InputManager::hasStableMultiTouchGeometry() const {
+bool InputManager::hasStableTranslationGeometry() const {
   for (uint8_t first = 0; first < trackedTouchContactCount; ++first) {
     for (uint8_t second = first + 1; second < trackedTouchContactCount; ++second) {
       const int startSeparationX =
@@ -890,9 +930,19 @@ bool InputManager::hasStableMultiTouchGeometry() const {
   return true;
 }
 
+bool InputManager::hasEligibleRotationScale() const {
+  if (trackedTouchContactCount != 2) return false;
+  const auto toGesturePoint = [](const TouchPoint& point) {
+    return freeink::input_detail::GesturePoint{point.x, point.y};
+  };
+  return freeink::input_detail::hasRotationScale(
+      toGesturePoint(multiTouchContacts[0].start), toGesturePoint(multiTouchContacts[1].start),
+      toGesturePoint(multiTouchContacts[0].last), toGesturePoint(multiTouchContacts[1].last));
+}
+
 bool InputManager::isMultiTouchTranslation(const unsigned long now) const {
   if (trackedTouchContactCount < 2 || now - multiTouchContacts[0].start.timestamp > TOUCH_MULTI_SWIPE_MAX_MS ||
-      !hasStableMultiTouchGeometry()) {
+      !hasStableTranslationGeometry()) {
     return false;
   }
 
@@ -932,7 +982,35 @@ bool InputManager::isMultiTouchTranslation(const unsigned long now) const {
   return false;
 }
 
+bool InputManager::classifyMultiTouchRotation(const unsigned long now) {
+  if (!multiTouchRotationEligible || trackedTouchContactCount != 2 ||
+      now - multiTouchContacts[0].start.timestamp > TOUCH_MULTI_SWIPE_MAX_MS) {
+    return false;
+  }
+
+  const auto toGesturePoint = [](const TouchPoint& point) {
+    return freeink::input_detail::GesturePoint{point.x, point.y};
+  };
+  freeink::input_detail::RotationResult result;
+  if (!freeink::input_detail::classifyRotation(
+          toGesturePoint(multiTouchContacts[0].start), toGesturePoint(multiTouchContacts[1].start),
+          toGesturePoint(multiTouchContacts[0].last), toGesturePoint(multiTouchContacts[1].last), result)) {
+    return false;
+  }
+
+  multiTouchRotationDegrees = result.degrees;
+  multiTouchRotationCenterX = result.centerX;
+  multiTouchRotationCenterY = result.centerY;
+  multiTouchRotationDurationMs = static_cast<uint16_t>(now - multiTouchContacts[0].start.timestamp);
+  multiTouchRotationEvent = true;
+  return true;
+}
+
 void InputManager::finishMultiTouchGesture(const unsigned long now) {
+  if (classifyMultiTouchRotation(now)) {
+    multiTouchGestureState = MultiTouchGestureState::Blocked;
+    return;
+  }
   if (isMultiTouchTranslation(now)) {
     uint32_t startX = 0;
     uint32_t startY = 0;
@@ -1000,7 +1078,11 @@ void InputManager::updateMultiTouchGesture(const TouchSnapshot& snapshot, const 
     if (!expandMultiTouchGesture(snapshot, now)) blockMultiTouchGesture();
     return;
   }
-  if (!matchMultiTouchSnapshot(snapshot) || !hasStableMultiTouchGeometry()) blockMultiTouchGesture();
+  if (!matchMultiTouchSnapshot(snapshot)) {
+    blockMultiTouchGesture();
+    return;
+  }
+  if (multiTouchRotationEligible && !hasEligibleRotationScale()) multiTouchRotationEligible = false;
 }
 
 bool InputManager::wasHomeKeyPressed() const { return touchHomeKeyEvent; }

--- a/libs/hardware/InputManager/src/MultiTouchGestureMath.h
+++ b/libs/hardware/InputManager/src/MultiTouchGestureMath.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace freeink::input_detail {
+
+struct GesturePoint {
+  int32_t x;
+  int32_t y;
+};
+
+struct RotationResult {
+  float degrees = 0.0f;
+  uint16_t centerX = 0;
+  uint16_t centerY = 0;
+};
+
+inline int64_t separationSquared(const GesturePoint& first, const GesturePoint& second) {
+  const int64_t dx = static_cast<int64_t>(second.x) - first.x;
+  const int64_t dy = static_cast<int64_t>(second.y) - first.y;
+  return dx * dx + dy * dy;
+}
+
+inline bool hasRotationScale(const GesturePoint& startFirst, const GesturePoint& startSecond,
+                             const GesturePoint& currentFirst, const GesturePoint& currentSecond) {
+  constexpr int64_t scalePercentSq = 100LL * 100LL;
+  constexpr int64_t minScalePercentSq = 80LL * 80LL;
+  constexpr int64_t maxScalePercentSq = 120LL * 120LL;
+  const int64_t startSeparationSq = separationSquared(startFirst, startSecond);
+  const int64_t currentSeparationSq = separationSquared(currentFirst, currentSecond);
+  return currentSeparationSq * scalePercentSq >= startSeparationSq * minScalePercentSq &&
+         currentSeparationSq * scalePercentSq <= startSeparationSq * maxScalePercentSq;
+}
+
+inline bool classifyRotation(const GesturePoint& startFirst, const GesturePoint& startSecond,
+                             const GesturePoint& endFirst, const GesturePoint& endSecond, RotationResult& result) {
+  constexpr int64_t minSeparationPxSq = 60LL * 60LL;
+  constexpr float minRotationDegrees = 20.0f;
+  constexpr double radiansToDegrees = 57.295779513082320876;
+
+  const int64_t startDx = static_cast<int64_t>(startSecond.x) - startFirst.x;
+  const int64_t startDy = static_cast<int64_t>(startSecond.y) - startFirst.y;
+  const int64_t endDx = static_cast<int64_t>(endSecond.x) - endFirst.x;
+  const int64_t endDy = static_cast<int64_t>(endSecond.y) - endFirst.y;
+  const int64_t startSeparationSq = separationSquared(startFirst, startSecond);
+  const int64_t endSeparationSq = separationSquared(endFirst, endSecond);
+
+  if (startSeparationSq < minSeparationPxSq || endSeparationSq < minSeparationPxSq) return false;
+  if (!hasRotationScale(startFirst, startSecond, endFirst, endSecond)) return false;
+
+  // Panel coordinates use a downward-positive Y axis, so a positive cross
+  // product is a clockwise visual rotation.
+  const int64_t cross = startDx * endDy - startDy * endDx;
+  const int64_t dot = startDx * endDx + startDy * endDy;
+  const float degrees =
+      static_cast<float>(std::atan2(static_cast<double>(cross), static_cast<double>(dot)) * radiansToDegrees);
+  if (std::fabs(degrees) < minRotationDegrees) return false;
+
+  result.degrees = degrees;
+  result.centerX =
+      static_cast<uint16_t>((static_cast<int64_t>(startFirst.x) + startSecond.x + endFirst.x + endSecond.x) / 4);
+  result.centerY =
+      static_cast<uint16_t>((static_cast<int64_t>(startFirst.y) + startSecond.y + endFirst.y + endSecond.y) / 4);
+  return true;
+}
+
+}  // namespace freeink::input_detail

--- a/libs/hardware/InputManager/test/host/run.sh
+++ b/libs/hardware/InputManager/test/host/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Builds and runs the allocation-free multi-touch gesture math tests.
+set -e
+cd "$(dirname "$0")"
+BUILD_DIR="${TMPDIR:-/tmp}/freeink-input-tests"
+mkdir -p "$BUILD_DIR"
+c++ -std=c++17 -Wall -Wextra -Werror test_multitouch_gesture_math.cpp -o "$BUILD_DIR/test_multitouch_gesture_math"
+"$BUILD_DIR/test_multitouch_gesture_math"

--- a/libs/hardware/InputManager/test/host/test_multitouch_gesture_math.cpp
+++ b/libs/hardware/InputManager/test/host/test_multitouch_gesture_math.cpp
@@ -1,0 +1,94 @@
+#include <cmath>
+#include <cstdio>
+
+#include "../../src/MultiTouchGestureMath.h"
+
+namespace {
+
+using freeink::input_detail::classifyRotation;
+using freeink::input_detail::GesturePoint;
+using freeink::input_detail::hasRotationScale;
+using freeink::input_detail::RotationResult;
+
+int checksRun = 0;
+int checksFailed = 0;
+
+#define CHECK(condition)                                               \
+  do {                                                                 \
+    ++checksRun;                                                       \
+    if (!(condition)) {                                                \
+      ++checksFailed;                                                  \
+      std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #condition); \
+    }                                                                  \
+  } while (0)
+
+bool near(const float actual, const float expected, const float tolerance = 0.1f) {
+  return std::fabs(actual - expected) <= tolerance;
+}
+
+void testClockwiseAndCounterClockwise() {
+  RotationResult result;
+  CHECK(classifyRotation({0, 0}, {100, 0}, {50, -50}, {50, 50}, result));
+  CHECK(near(result.degrees, 90.0f));
+  CHECK(result.centerX == 50);
+  CHECK(result.centerY == 0);
+
+  CHECK(classifyRotation({0, 0}, {100, 0}, {50, 50}, {50, -50}, result));
+  CHECK(near(result.degrees, -90.0f));
+}
+
+void testAngleWraparound() {
+  RotationResult result;
+  CHECK(!classifyRotation({200, 200}, {102, 217}, {200, 200}, {102, 183}, result));
+  CHECK(classifyRotation({200, 200}, {102, 217}, {200, 200}, {106, 166}, result));
+  CHECK(result.degrees > 20.0f && result.degrees < 30.0f);
+}
+
+void testContactOrderIndependence() {
+  RotationResult forward;
+  RotationResult reversed;
+  CHECK(classifyRotation({0, 0}, {100, 0}, {50, -50}, {50, 50}, forward));
+  CHECK(classifyRotation({100, 0}, {0, 0}, {50, 50}, {50, -50}, reversed));
+  CHECK(near(forward.degrees, reversed.degrees));
+}
+
+void testRejectionThresholds() {
+  RotationResult result;
+  CHECK(!classifyRotation({0, 0}, {100, 0}, {2, -17}, {98, 17},
+                          result));  // Below 20 degrees.
+  CHECK(!classifyRotation({0, 0}, {50, 0}, {25, -25}, {25, 25},
+                          result));  // Span below 60 px.
+  CHECK(!classifyRotation({0, 0}, {100, 0}, {-10, -10}, {110, 10},
+                          result));  // Pinch/spread over 20%.
+  CHECK(!classifyRotation({0, 0}, {100, 0}, {80, 0}, {180, 0},
+                          result));  // Translation only.
+}
+
+void testScaleEligibilityCanLatchIntermediatePinch() {
+  CHECK(hasRotationScale({0, 0}, {100, 0}, {0, 0}, {80, 0}));
+  CHECK(hasRotationScale({0, 0}, {100, 0}, {0, 0}, {120, 0}));
+  CHECK(!hasRotationScale({0, 0}, {100, 0}, {0, 0}, {79, 0}));
+  CHECK(!hasRotationScale({0, 0}, {100, 0}, {0, 0}, {121, 0}));
+}
+
+void testRotationWinsWithTranslation() {
+  RotationResult result;
+  CHECK(classifyRotation({0, 0}, {100, 0}, {130, 50}, {130, 150}, result));
+  CHECK(near(result.degrees, 90.0f));
+  CHECK(result.centerX == 90);
+  CHECK(result.centerY == 50);
+}
+
+}  // namespace
+
+int main() {
+  testClockwiseAndCounterClockwise();
+  testAngleWraparound();
+  testContactOrderIndependence();
+  testRejectionThresholds();
+  testScaleEligibilityCanLatchIntermediatePinch();
+  testRotationWinsWithTranslation();
+
+  std::printf("%d checks, %d failures\n", checksRun, checksFailed);
+  return checksFailed == 0 ? 0 : 1;
+}

--- a/libs/ui/FreeInkUI/include/FreeInkUIInputManager.h
+++ b/libs/ui/FreeInkUI/include/FreeInkUIInputManager.h
@@ -27,10 +27,9 @@ struct ButtonBindings {
 };
 
 // Call after InputManager::update(). This adapter carries single-contact UI
-// edges only. InputManager also exposes panel-native 2-4 contact translation
-// endpoints and their contact count; applications that use them should map
-// their direction and route them before this adapter's normal single-touch
-// fallback.
+// edges only. InputManager also exposes completed panel-native 2-4 contact
+// translations and two-contact rotations; applications that use them should
+// route those gestures before this adapter's normal single-touch fallback.
 inline InputSnapshot snapshotFrom(const InputManager& input, const ButtonBindings& bindings = ButtonBindings{}) {
   InputSnapshot snapshot;
   snapshot.focusPrev = input.wasPressed(bindings.focusPrev);


### PR DESCRIPTION
## Summary

Adds completed two-finger rotation gesture recognition for GT911 touch devices.

- Exposes synchronous and async rotation events with signed angle, normalized center point, and duration.
- Recognizes rotations only when two contacts stay within a stable 80–120% separation range, have at least a 60 px span, and rotate at least 20°.
- Gives an accepted rotation precedence over multi-touch translation, preventing one gesture from triggering both outcomes.
- Documents the GT911 multi-touch rotation capability and adds host-side math coverage.

## Validation

- Added host tests covering clockwise/counterclockwise angles, wraparound, contact-order independence, rejection thresholds, scale eligibility, and rotation-versus-translation precedence.
- Verified working in CrossInk on X4 Pro and Sticky to change reader orientation