### PR TITLE
LilyGo T5S3: profile corrections + LGFX grayscale fixes

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/LgfxEpdDriver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/LgfxEpdDriver.cpp
@@ -124,17 +124,6 @@ uint16_t g_w = 0, g_h = 0, g_wb = 0;
 
 constexpr uint8_t kGrayBlack = 0x00, kGrayDark = 0x55, kGrayLight = 0xAA, kGrayWhite = 0xFF;
 
-// (base, lsb, msb) per pixel -> 4 gray levels, matching the reference port: a set
-// base bit is white; otherwise msb/lsb pick light/dark; clear is black.
-inline uint8_t grayValue(uint8_t base, uint8_t lsb, uint8_t msb, uint8_t mask) {
-  if (base & mask) return kGrayWhite;
-  const bool l = lsb & mask, m = msb & mask;
-  if (m && l) return kGrayDark;
-  if (m) return kGrayLight;
-  if (l) return kGrayDark;
-  return kGrayBlack;
-}
-
 void allocCanvas(uint16_t w, uint16_t h) {
   g_w = w;
   g_h = h;
@@ -165,24 +154,48 @@ void fillCanvasBW(const uint8_t* fb) {
   }
 }
 
-// Combine the B/W base + buffered LSB/MSB planes into the 8-bit gray canvas.
-void fillCanvasGray(const uint8_t* base) {
+// Overlay the buffered LSB/MSB planes onto the B/W canvas the base push left
+// behind, darkening only the pixels a plane actually selects.
+//
+// This used to take the base frame as an argument and rebuild every pixel from
+// it. That looked reasonable but could not work: displayGray() is handed
+// FreeInkDisplay::frameBuffer, and the host's plane dance (clear to 0x00, render
+// text-only, copy the plane out, call displayGray) leaves the LAST PLANE there,
+// not the page. Ssd1677Driver::displayGray() opens with `(void)fb` -- its planes
+// are already in controller RAM and the panel retains the B/W image -- so nothing
+// ever noticed that the buffer held a plane. Here it painted the whole background
+// black and left only the anti-aliased marks standing.
+//
+// The canvas already holds the B/W frame from the base push and is not cleared by
+// pushSprite(), so it IS the base. Reading it instead of a caller-supplied pointer
+// removes the ambiguity rather than relying on the caller to resolve it.
+void overlayCanvasGray() {
   if (!g_canvas || !g_lsb || !g_msb) return;
   auto* dst = static_cast<uint8_t*>(g_canvas->getBuffer());
   if (!dst) return;
   for (uint16_t y = 0; y < g_h; ++y) {
-    const uint8_t* brow = base + static_cast<uint32_t>(y) * g_wb;
     const uint8_t* lrow = g_lsb + static_cast<uint32_t>(y) * g_wb;
     const uint8_t* mrow = g_msb + static_cast<uint32_t>(y) * g_wb;
     uint8_t* drow = dst + static_cast<uint32_t>(y) * g_w;
     for (uint16_t bx = 0; bx < g_wb; ++bx) {
+      const uint8_t l = lrow[bx], m = mrow[bx];
+      if ((l | m) == 0) continue;  // no selector bits in this byte — leave the B/W run alone
       for (uint8_t bit = 0; bit < 8; ++bit) {
         const uint8_t mask = 0x80 >> bit;
-        drow[bx * 8 + bit] = grayValue(brow[bx], lrow[bx], mrow[bx], mask);
+        const bool lb = (l & mask) != 0, mb = (m & mask) != 0;
+        if (!lb && !mb) continue;
+        drow[bx * 8 + bit] = mb && !lb ? kGrayLight : kGrayDark;
       }
     }
   }
 }
+
+// The epd_mode of the last base push. Panel_EPD's per-pixel diff keys on the
+// epd_mode LUT offset, so the grayscale overlay must be pushed with the SAME mode
+// the base used or every pixel is re-driven (a full-screen flash). displayGray()
+// used to hardcode epd_fast while display() maps HALF/FULL to epd_text, so any
+// page refreshed with those modes flashed when its AA pass ran.
+lgfx::epd_mode::epd_mode_t g_lastBaseEpdMode = lgfx::epd_mode::epd_fast;
 
 void pushCanvas(lgfx::epd_mode::epd_mode_t epdMode) {
   if (!g_canvas) return;
@@ -220,8 +233,9 @@ void LgfxEpdDriver::display(EpdBus& bus, const uint8_t* fb, const uint8_t* prev,
   (void)bus;
   (void)prev;
 #if FREEINK_DRIVER_LGFX_EPD
-  fillCanvasBW(fb);          // expand the 1-bpp frame into the gray canvas
-  pushCanvas(epdModeFor(mode));
+  fillCanvasBW(fb);  // expand the 1-bpp frame into the gray canvas
+  g_lastBaseEpdMode = epdModeFor(mode);
+  pushCanvas(g_lastBaseEpdMode);
   if (turnOff) g_dev.sleep();
 #else
   (void)fb;
@@ -270,12 +284,14 @@ void LgfxEpdDriver::displayGray(EpdBus& bus, const uint8_t* fb, bool turnOff, co
   (void)lut;
   (void)factoryMode;
 #if FREEINK_DRIVER_LGFX_EPD
-  fillCanvasGray(fb);  // combine base + LSB/MSB planes -> 4-level gray
-  // Same mode as the B/W base push: Panel_EPD's per-pixel diff keys on the
-  // epd_mode LUT offset, so switching modes here would re-drive every pixel
-  // (full-screen inversion flash). The board's fast LUT carries both the B/W
-  // drive and the AA gray-nudge columns, so one mode serves both pushes.
-  pushCanvas(lgfx::epd_mode::epd_fast);
+  (void)fb;             // the canvas from the base push IS the base; see overlayCanvasGray()
+  overlayCanvasGray();  // darken only the pixels the planes select
+  // Same mode as the B/W base push, and now actually the same: Panel_EPD's
+  // per-pixel diff keys on the epd_mode LUT offset, so switching modes here
+  // re-drives every pixel (full-screen flash). This was hardcoded to epd_fast
+  // while display() maps HALF/FULL to epd_text, so a page refreshed with either
+  // of those flashed when its AA pass ran.
+  pushCanvas(g_lastBaseEpdMode);
   if (turnOff) g_dev.sleep();
 #else
   (void)fb;

--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -256,9 +256,9 @@
 // On-board I2C sensors. Each lib (Rtc / EnvironmentSensor / Imu) compiles its
 // I2C driver only when its flag is set; otherwise it links stub bodies.
 #ifndef FREEINK_CAP_RTC
-#define FREEINK_CAP_RTC \
+#define FREEINK_CAP_RTC                                                                             \
   (FREEINK_DEVICE_X3 || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || \
-   FREEINK_DEVICE_PAPERS3)
+   FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_LILYGO)
 #endif
 #ifndef FREEINK_CAP_TEMP_HUMIDITY
 #define FREEINK_CAP_TEMP_HUMIDITY (FREEINK_DEVICE_STICKY)
@@ -693,9 +693,15 @@ constexpr TouchConfig NO_TOUCH = {TouchController::None,
 // LilyGo T5 S3 Pro Lite GT911 touch (shared I2C bus). The digitizer reports a
 // portrait 540x960 frame on the landscape 960x540 panel, so swap axes into the
 // panel-native display frame before app-level orientation mapping.
+// hasHomeKey=true: the board HAS a capacitive home key below the panel. The vendor
+// wiki's button list ("RST + BOOT + IO48 + PWR") omits it entirely, so it was found
+// by tracing the GT911 status bit (0x10) on hardware. InputManager reads that bit
+// unconditionally, so detection always worked -- it was the consumers gated on this
+// flag (wasHomeGesture()/wasHomeKeyHold()) that discarded every press. On a board
+// with one physical nav key that is a real loss.
 constexpr TouchConfig LILYGO_T5_PRO_GT911 = {
-    TouchController::Gt911, 39,   40,    3,   9, 0x5D, 0, 959, 0, 539, false, 0x14, false, true,
-    PIN_UNASSIGNED,         true, false, true};  // powerEnable, swapXY=true, flipX=false, flipY=true
+    TouchController::Gt911, 39,   40,    3,    9, 0x5D, 0, 959, 0, 539, false, 0x14, false, true,
+    PIN_UNASSIGNED,         true, false, true, true};  // powerEnable, swapXY, flipX, flipY, hasHomeKey
 constexpr FrontlightConfig NO_FRONTLIGHT = {PIN_UNASSIGNED, 0, 0, true};
 constexpr AudioConfig NO_AUDIO = {AudioOutput::None,
                                   PIN_UNASSIGNED,
@@ -1136,11 +1142,23 @@ constexpr BoardProfile LILYGO_T5S3 = {
     NO_SDMMC,
     {39, 40, 400000, 0x55, 0x6B},  // BQ27220 gauge (0x55) + BQ25896 charger (0x6B) on SDA39/SCL40
     NO_MIC,
-    NO_SENSORS,
+    // Battery-backed RTC on the shared main I2C bus. The vendor schematic
+    // (hardware/T5 E-paper S3 Pro V1.0 24-12-24.pdf, page 3 / U3) shows a
+    // PCF8563TS at 0x51; the README's product table says PCF85063, and the
+    // vendor's own docs/pinmap.md notes say to prefer the schematic and the
+    // mounted part. Was NO_SENSORS, so the board kept time in software and lost
+    // it whenever power was actually cut rather than merely deep-slept.
+    {39, 40, 400000, 0x51, 0, 0, 0, RtcType::Pcf8563, ImuType::None},
     1.2f,  // uiScale: 4.7" 960x540 touch (~234 PPI) — finger-sized chrome, like Sticky
     // Power latch: main-power MOSFET on GPIO2, driven HIGH first thing in boot
     // via holdPowerRails() or the board powers off when USB is unplugged.
-    {2}};
+    {2},
+    0,  // displayControllerVariant: not probed on this panel
+    // Bezel: this case sits closer over the glass at the sides than the X4's, so
+    // the default 3px leaves the first and last characters of a line hard to
+    // read. Measured by eye on hardware in two passes (3 -> 6 -> 8); top/bottom
+    // are correct at the defaults. Compare the X4 Pro's 7px sides.
+    {9, 8, 3, 8}};
 
 // --- M5Paper v1.1 4.7" (ED047TC1 behind an IT8951E controller) — ESP32 --------
 // 540x960 16-gray panel driven through an IT8951E timing controller over SPI


### PR DESCRIPTION
Found while bringing the LilyGo T5 E-Paper S3 Pro up on WitchReader. Two
independent commits, one file each.

## 1. `BoardConfig` — profile corrections (`2ebfc48`)

All four verified on hardware.

| Change | Why |
|---|---|
| `LILYGO_T5_PRO_GT911.hasHomeKey = true` | The board **has** a capacitive home key. The vendor wiki's button list (*"RST + BOOT + IO48 + PWR"*) omits it, so it was found by tracing the GT911 status bit `0x10`. `InputManager` reads that bit unconditionally, so detection always worked — the *consumers* gated on this flag (`wasHomeGesture()`, `wasHomeKeyHold()`) discarded every press. On a board whose only other nav input is one expander button, that is the difference between usable and not. |
| `sensors` → PCF8563 @ `0x51` | The board has a battery-backed RTC and the profile said `NO_SENSORS`, so it kept time in software and lost it on any real power cut. Schematic `hardware/T5 E-paper S3 Pro V1.0 24-12-24.pdf` page 3 / U3 shows a **PCF8563TS at 0x51**. The README's product table says PCF85063; the vendor's own `docs/pinmap.md` notes say to prefer the schematic and the mounted part. |
| `FREEINK_CAP_RTC` += `FREEINK_DEVICE_LILYGO` | Without it the `Rtc` lib links stub bodies and `begin()` returns false however correct the profile is. The two changes are only useful together. |
| `viewableInsets` sides `3 → 8` | This case sits closer over the glass than the X4's, whose value the default carries; 3px left the first and last characters of each line hard to read. Measured by eye in two passes; top/bottom are right at the defaults. Compare the X4 Pro's 7px sides. |

## 2. `LgfxEpdDriver` — grayscale path (`492c799`)

Both invisible until a host actually runs an AA pass on this panel.

**a. `displayGray()` treated its `fb` argument as the B/W base.** It isn't.
The facade passes `FreeInkDisplay::frameBuffer`, and the host's plane dance
(clear to `0x00`, render text-only, copy the plane out, call `displayGray`)
leaves the **last plane** there. Every background pixel therefore mapped to
`kGrayBlack`: the page inverted, the text vanished, and only the anti-aliased
marks remained.

`Ssd1677Driver::displayGray()` opens with `(void)fb` — its planes are already in
controller RAM and the panel retains the B/W image — so the argument was
effectively dead for the driver the caller was written against, and nobody
noticed it carried a plane.

Rather than push the contract back onto callers, the driver now overlays onto the
canvas the base push left behind: `pushSprite()` does not clear it, so the canvas
**is** the base. Only pixels a selector plane actually picks are darkened.

**b. `displayGray()` hardcoded `epd_fast`** while `display()` maps `HALF`/`FULL`
to `epd_text`. `Panel_EPD`'s per-pixel diff keys on the `epd_mode` LUT offset, so
a mode switch between base push and overlay re-drives every pixel — a full-screen
flash on any page refreshed with HALF or FULL. The mode of the last base push is
now remembered and reused, which is what the existing comment there already
claimed was happening.

## Validation

- Profile changes and **2a**: device-validated. The inversion is gone and
  anti-aliased text renders correctly.
- **2b**: reasoned from the driver's own documented behaviour and the arithmetic,
  **not** yet observed — the flash could not appear while the AA pass never
  reached the panel. Flagging that explicitly rather than implying it was tested.