### PR TITLE
fix: keep virtual list rendering inside its item window

### DIFF
--- a/libs/ui/FreeInkUI/include/components/lists/list.h
+++ b/libs/ui/FreeInkUI/include/components/lists/list.h
@@ -43,6 +43,12 @@ struct ListProps {
   // so the caller must keep the window covering that range (refresh it after
   // viewport changes, before list()). 0 = items is the full array.
   uint16_t itemsWindowFirst = 0;
+  // Number of ListItems supplied in `items` when it is a virtual window.
+  // Set this whenever itemsWindowFirst is non-zero (or the supplied array is
+  // otherwise shorter than count), so optional previews can stay within the
+  // materialized data. 0 preserves the full-array behavior for existing
+  // callers.
+  uint16_t itemsWindowCount = 0;
   // First item index drawn at the top of the rect. The list is virtualized:
   // only the rows that fully fit inside the rect are laid out, drawn, and
   // registered for interaction. Use listVisibleRows()/listTopIndexFor() to
@@ -345,6 +351,12 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
   uint16_t consumedIndexes = 0; // item AND header indexes laid out from top
   bool selectedDrawn = false;
   for (uint16_t i = top; i < props.count; ++i) {
+    // Stop before reading the next window entry. The size/layout work below
+    // dereferences `item`, so checking after it would require callers that
+    // virtualize their data to provide one extra, otherwise out-of-window row.
+    if (drawnRows >= visible || i >= end || i < props.itemsWindowFirst ||
+        (props.itemsWindowCount > 0 && i - props.itemsWindowFirst >= props.itemsWindowCount))
+      break;
     const ListItem &item = props.items[i - props.itemsWindowFirst];
     if (item.isHeader) {
       const int16_t pad = i != top ? props.sectionGap : 0;
@@ -441,8 +453,7 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
     } else if (labelLines > 1) {
       itemH = static_cast<int16_t>(rowH + labelLh * (labelLines - 1));
     }
-    if (static_cast<int16_t>(cursorY + itemH) > rowArea.bottom() ||
-        drawnRows >= visible || i >= end)
+    if (static_cast<int16_t>(cursorY + itemH) > rowArea.bottom())
       break;
     ++drawnRows;
     ++consumedIndexes;
@@ -657,7 +668,8 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
   if (props.partialTrailingRow && overflows && visible > 0) {
     const uint16_t partialIndex = static_cast<uint16_t>(top + visible);
     const int16_t remainingH = static_cast<int16_t>(rowArea.bottom() - cursorY);
-    if (partialIndex < props.count &&
+    if (partialIndex < props.count && partialIndex >= props.itemsWindowFirst &&
+        (props.itemsWindowCount == 0 || partialIndex - props.itemsWindowFirst < props.itemsWindowCount) &&
         remainingH >= props.partialTrailingMinHeight) {
       const ListItem &item = props.items[partialIndex - props.itemsWindowFirst];
       if (!item.isHeader && item.label != nullptr && item.label[0] != '\0') {

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -53,10 +53,14 @@ class FakeDrawTarget : public DrawTarget {
 
   Op ops[256]{};
   size_t opCount = 0;
+  mutable bool measuredForbiddenLabel = false;
+  bool drewForbiddenLabel = false;
   int16_t charWidth = 6;
   int16_t lineH = 12;
 
   Size measureText(FontId, const char* text, TextStyle) const override {
+    if (text != nullptr && std::strcmp(text, "must-not-measure") == 0)
+      measuredForbiddenLabel = true;
     return Size{static_cast<int16_t>(charWidth * static_cast<int16_t>(std::strlen(text))), lineH};
   }
   int16_t lineHeight(FontId) const override { return lineH; }
@@ -74,7 +78,9 @@ class FakeDrawTarget : public DrawTarget {
   void triangle(Point a, Point, Point c, Paint paint) override {
     record(Op::Triangle, Rect{a.x, a.y, static_cast<int16_t>(c.x - a.x), static_cast<int16_t>(c.y - a.y)}, paint);
   }
-  void text(Rect rect, const char*, TextStyle style) override {
+  void text(Rect rect, const char* text, TextStyle style) override {
+    if (text != nullptr && std::strcmp(text, "must-not-measure") == 0)
+      drewForbiddenLabel = true;
     record(Op::Text, rect, Paint::solid(style.color), 0, CornersAll, style.rotation);
   }
   void bitmap(Rect rect, BitmapRef, BitmapMode, Paint foreground, Rotation rotation) override {
@@ -632,6 +638,7 @@ void testListItemsWindow() {
   ListProps props;
   props.items = window;
   props.itemsWindowFirst = 10;
+  props.itemsWindowCount = 8;
   props.count = 100;
   props.topIndex = 12;
   props.selectedIndex = 14;
@@ -642,6 +649,67 @@ void testListItemsWindow() {
   CHECK_EQ(interactions.count(), 5u);
   CHECK_EQ(interactions.data()[0].value, 12);
   CHECK_EQ(interactions.data()[4].value, 16);
+}
+
+// The virtual window only needs rows that can actually be drawn. In
+// particular, list() must not measure an extra row after the viewport is full:
+// callers often store exactly the visible window, so that read would be past
+// their ListItem array.
+void testListItemsWindowStopsBeforePastEndMeasurement() {
+  FakeDrawTarget draw;
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+  InteractionBuffer<32> interactions;
+  Frame<32> frame(draw, device, input, interactions);
+
+  ListItem window[6]{};
+  for (int i = 0; i < 6; ++i) {
+    window[i].label = i == 5 ? "must-not-measure" : "row";
+    window[i].actionValue = static_cast<int16_t>(10 + i);
+  }
+
+  ListProps props;
+  props.items = window;
+  props.itemsWindowFirst = 10;
+  props.itemsWindowCount = 5;
+  props.count = 100;
+  props.topIndex = 10;
+  props.action = 9;
+  props.rowHeight = 19;
+  list(frame, Rect{0, 0, 480, 95}, props);  // exactly 5 visible rows
+
+  CHECK_EQ(interactions.count(), 5u);
+  CHECK(!draw.measuredForbiddenLabel);
+  CHECK(!draw.drewForbiddenLabel);
+}
+
+void testListItemsWindowSkipsUnavailablePartialPreview() {
+  FakeDrawTarget draw;
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+  InteractionBuffer<32> interactions;
+  Frame<32> frame(draw, device, input, interactions);
+
+  ListItem window[6]{};
+  for (int i = 0; i < 6; ++i) {
+    window[i].label = i == 5 ? "must-not-measure" : "row";
+    window[i].actionValue = static_cast<int16_t>(10 + i);
+  }
+
+  ListProps props;
+  props.items = window;
+  props.itemsWindowFirst = 10;
+  props.itemsWindowCount = 5;
+  props.count = 100;
+  props.topIndex = 10;
+  props.action = 9;
+  props.rowHeight = 20;
+  props.partialTrailingRow = true;
+  list(frame, Rect{0, 0, 480, 118}, props);  // five rows plus an 18px preview
+
+  CHECK_EQ(interactions.count(), 5u);
+  CHECK(!draw.measuredForbiddenLabel);
+  CHECK(!draw.drewForbiddenLabel);
 }
 
 void testListNavLayoutFeedback() {
@@ -3041,6 +3109,8 @@ int main() {
   testListVirtualization();
   testListClampsBadTopIndex();
   testListItemsWindow();
+  testListItemsWindowStopsBeforePastEndMeasurement();
+  testListItemsWindowSkipsUnavailablePartialPreview();
   testListNavLayoutFeedback();
   testListNavConvergesThroughRealList();
   testListCanUseFullTitleWidthWithShortValue();


### PR DESCRIPTION
## Summary

- Add `itemsWindowCount` so virtualized lists can declare the number of materialized `ListItem`s.
- Stop before accessing an item outside that supplied window during normal list layout.
- Apply the same bound to optional partial trailing-row previews.
- Add regression coverage for both the extra-row measurement and partial-preview cases.

## Why

A virtual list can only create/store the rows currently visible. Previously, list layout could inspect one additional row after the viewport filled, and partial previews could access an unavailable next item. Both cases could read beyond the caller’s item array causing a crash. This was found after porting the wrapped-row pagination work from crosspoint-reader/crosspoint-reader#3072 (`b3d1e79…`) to Crossink's windowed File Browser list. 