### PR TITLE
fix: stop credential parsing aborting on a tight heap

### DIFF
--- a/libs/book/ContentProtection/src/Credential.cpp
+++ b/libs/book/ContentProtection/src/Credential.cpp
@@ -22,7 +22,7 @@ void assignField(std::string_view key, std::string_view value, Credential* out) 
   else if (key == "privateLicenseKey") field = &out->privateLicenseKey;
   else if (key == "devicesalt") field = &out->deviceSalt;
   // signingKeyPem / signingCertPem / future fields: accepted, ignored here
-  if (field) field->assign(value.data(), value.size());
+  if (field) field->assign(value.begin(), value.end());
 }
 
 // Slices the text in place. The only allocations left are the credential's own
@@ -60,15 +60,20 @@ bool parseCredential(ByteSource& source, Credential* out) {
   if (size == 0 || size > kMaxBundleBytes) return false;
 
   // Nothrow, because this runs on targets built with -fno-exceptions, where a
-  // failed operator new calls abort() rather than returning. Reading the bundle
-  // into a std::string took a throwing allocation of up to the cap above on a
-  // heap that, on an ESP32-C3 during a library rescan, can be down to ~12KB.
-  auto buf = std::unique_ptr<char[]>(new (std::nothrow) char[static_cast<size_t>(size)]);
+  // failed operator new calls abort() rather than returning. Reading the
+  // bundle into a std::string took a throwing allocation of up to the cap above,
+  // which on a small-RAM target is taken against whatever heap happens to be left.
+  const size_t capacity = static_cast<size_t>(size);
+  auto buf = std::unique_ptr<char[]>(new (std::nothrow) char[capacity]);
   if (!buf) return false;
 
-  const int32_t n = source.readAt(0, buf.get(), static_cast<uint32_t>(size));
+  const int32_t n = source.readAt(0, buf.get(), static_cast<uint32_t>(capacity));
   if (n <= 0) return false;
-  return parseText(std::string_view(buf.get(), static_cast<size_t>(n)), out);
+  // ByteSource is implemented by the caller, so treat a length longer than the
+  // buffer as the source over-reporting rather than reading past the end.
+  size_t got = static_cast<size_t>(n);
+  if (got > capacity) got = capacity;
+  return parseText(std::string_view(buf.get(), got), out);
 }
 
 }  // namespace content

--- a/libs/book/ContentProtection/src/Credential.cpp
+++ b/libs/book/ContentProtection/src/Credential.cpp
@@ -1,32 +1,39 @@
 #include "Credential.h"
 
+#include <memory>
+#include <new>
+#include <string_view>
+
 namespace freeink {
 namespace content {
 
 namespace {
 
-void assignField(const std::string& key, const std::string& value, Credential* out) {
-  if (key == "username") out->username = value;
-  else if (key == "userUuid") out->userUuid = value;
-  else if (key == "deviceUuid") out->deviceUuid = value;
-  else if (key == "serial") out->serial = value;
-  else if (key == "fingerprint") out->fingerprint = value;
-  else if (key == "privateLicenseKey") out->privateLicenseKey = value;
-  else if (key == "devicesalt") out->deviceSalt = value;
+// Bundles are a few KB; the cap only guards against a wildly wrong size().
+constexpr uint64_t kMaxBundleBytes = 256 * 1024;
+
+void assignField(std::string_view key, std::string_view value, Credential* out) {
+  std::string* field = nullptr;
+  if (key == "username") field = &out->username;
+  else if (key == "userUuid") field = &out->userUuid;
+  else if (key == "deviceUuid") field = &out->deviceUuid;
+  else if (key == "serial") field = &out->serial;
+  else if (key == "fingerprint") field = &out->fingerprint;
+  else if (key == "privateLicenseKey") field = &out->privateLicenseKey;
+  else if (key == "devicesalt") field = &out->deviceSalt;
   // signingKeyPem / signingCertPem / future fields: accepted, ignored here
+  if (field) field->assign(value.data(), value.size());
 }
 
-}  // namespace
-
-bool parseCredential(const std::string& text, Credential* out) {
-  size_t pos = 0;
+// Slices the text in place. The only allocations left are the credential's own
+// fields -- see the note on parseCredential(ByteSource&) for why that matters.
+bool parseText(std::string_view text, Credential* out) {
   bool headerSeen = false;
-  while (pos < text.size()) {
-    const size_t nl = text.find('\n', pos);
-    const size_t end = (nl == std::string::npos) ? text.size() : nl;
-    std::string line = text.substr(pos, end - pos);
-    pos = end + 1;
-    if (!line.empty() && line.back() == '\r') line.pop_back();
+  while (!text.empty()) {
+    const size_t nl = text.find('\n');
+    std::string_view line = text.substr(0, nl);
+    text = (nl == std::string_view::npos) ? std::string_view() : text.substr(nl + 1);
+    if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
     if (line.empty()) continue;
 
     if (!headerSeen) {
@@ -36,21 +43,32 @@ bool parseCredential(const std::string& text, Credential* out) {
     }
 
     const size_t colon = line.find(": ");
-    if (colon == std::string::npos) continue;
+    if (colon == std::string_view::npos) continue;
     assignField(line.substr(0, colon), line.substr(colon + 2), out);
   }
   return headerSeen && out->complete();
 }
 
+}  // namespace
+
+bool parseCredential(const std::string& text, Credential* out) {
+  return parseText(text, out);
+}
+
 bool parseCredential(ByteSource& source, Credential* out) {
   const uint64_t size = source.size();
-  if (size == 0 || size > 256 * 1024) return false;  // bundles are a few KB
-  std::string text;
-  text.resize(static_cast<size_t>(size));
-  const int32_t n = source.readAt(0, text.data(), static_cast<uint32_t>(size));
+  if (size == 0 || size > kMaxBundleBytes) return false;
+
+  // Nothrow, because this runs on targets built with -fno-exceptions, where a
+  // failed operator new calls abort() rather than returning. Reading the bundle
+  // into a std::string took a throwing allocation of up to the cap above on a
+  // heap that, on an ESP32-C3 during a library rescan, can be down to ~12KB.
+  auto buf = std::unique_ptr<char[]>(new (std::nothrow) char[static_cast<size_t>(size)]);
+  if (!buf) return false;
+
+  const int32_t n = source.readAt(0, buf.get(), static_cast<uint32_t>(size));
   if (n <= 0) return false;
-  text.resize(static_cast<size_t>(n));
-  return parseCredential(text, out);
+  return parseText(std::string_view(buf.get(), static_cast<size_t>(n)), out);
 }
 
 }  // namespace content

--- a/libs/book/ContentProtection/test/host/run.sh
+++ b/libs/book/ContentProtection/test/host/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Builds and runs the ContentProtection credential tests. No device or
+# PlatformIO needed -- Credential.cpp is freestanding C++17.
+set -e
+cd "$(dirname "$0")"
+BUILD_DIR="${TMPDIR:-/tmp}/contentprotection-tests"
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+c++ -std=c++17 -Wall -Wextra -Werror -I../../include \
+  ../../src/Credential.cpp test_credential.cpp \
+  -o "$BUILD_DIR/test_credential"
+
+"$BUILD_DIR/test_credential"

--- a/libs/book/ContentProtection/test/host/test_credential.cpp
+++ b/libs/book/ContentProtection/test/host/test_credential.cpp
@@ -136,6 +136,23 @@ void testShortRead() {
   assert(c.privateLicenseKey == "BASE64KEY==");
 }
 
+// A ByteSource that over-reports how much it read must not make the parser
+// walk past the end of its buffer.
+class LyingSource : public ByteSource {
+ public:
+  int32_t readAt(uint64_t, void* dst, uint32_t len) override {
+    memset(dst, 'A', len);
+    return static_cast<int32_t>(len) + 4096;  // claims more than it wrote
+  }
+  uint64_t size() const override { return 64; }
+};
+
+void testOverReportedRead() {
+  LyingSource src;
+  Credential c;
+  assert(!parseCredential(src, &c));  // garbage, but must not read out of bounds
+}
+
 }  // namespace
 
 int main() {
@@ -148,6 +165,7 @@ int main() {
   testByteSource();
   testByteSourceSizeGuards();
   testShortRead();
+  testOverReportedRead();
   printf("credential: all tests passed\n");
   return 0;
 }

--- a/libs/book/ContentProtection/test/host/test_credential.cpp
+++ b/libs/book/ContentProtection/test/host/test_credential.cpp
@@ -1,0 +1,153 @@
+// Host tests for credential parsing. No device or PlatformIO needed --
+// Credential.cpp is freestanding C++17 and depends only on ByteSource.
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "Credential.h"
+
+using freeink::content::ByteSource;
+using freeink::content::Credential;
+using freeink::content::parseCredential;
+
+namespace {
+
+class MemorySource : public ByteSource {
+ public:
+  explicit MemorySource(std::string data) : data_(std::move(data)) {}
+  int32_t readAt(uint64_t offset, void* dst, uint32_t len) override {
+    if (offset >= data_.size()) return 0;
+    const size_t avail = data_.size() - static_cast<size_t>(offset);
+    const size_t n = len < avail ? len : avail;
+    memcpy(dst, data_.data() + offset, n);
+    return static_cast<int32_t>(n);
+  }
+  uint64_t size() const override { return sizeOverride_ ? sizeOverride_ : data_.size(); }
+  void setSizeOverride(uint64_t v) { sizeOverride_ = v; }
+
+ private:
+  std::string data_;
+  uint64_t sizeOverride_ = 0;
+};
+
+const char* kValid =
+    "FREEINK-CONTENT-KEY 1\n"
+    "username: reader\n"
+    "userUuid: u-123\n"
+    "deviceUuid: d-456\n"
+    "privateLicenseKey: BASE64KEY==\n";
+
+void testValid() {
+  Credential c;
+  assert(parseCredential(std::string(kValid), &c));
+  assert(c.username == "reader");
+  assert(c.userUuid == "u-123");
+  assert(c.deviceUuid == "d-456");
+  assert(c.privateLicenseKey == "BASE64KEY==");
+  assert(c.complete());
+}
+
+void testCrlfAndBlankLines() {
+  Credential c;
+  const std::string text =
+      "FREEINK-CONTENT-KEY 1\r\n"
+      "\r\n"
+      "userUuid: u-1\r\n"
+      "deviceUuid: d-1\r\n"
+      "privateLicenseKey: K\r\n";
+  assert(parseCredential(text, &c));
+  assert(c.userUuid == "u-1");
+  assert(c.privateLicenseKey == "K");
+}
+
+void testNoTrailingNewline() {
+  Credential c;
+  std::string text(kValid);
+  text.pop_back();  // drop the final '\n'
+  assert(parseCredential(text, &c));
+  assert(c.privateLicenseKey == "BASE64KEY==");
+}
+
+void testRejects() {
+  Credential c1;
+  assert(!parseCredential(std::string("NOT-A-HEADER\nuserUuid: u\n"), &c1));
+
+  Credential c2;  // header present, mandatory fields missing
+  assert(!parseCredential(std::string("FREEINK-CONTENT-KEY 1\nusername: r\n"), &c2));
+
+  Credential c3;
+  assert(!parseCredential(std::string(""), &c3));
+}
+
+void testUnknownFieldsIgnored() {
+  Credential c;
+  const std::string text =
+      "FREEINK-CONTENT-KEY 1\n"
+      "signingCertPem: whatever\n"
+      "somethingNew: value\n"
+      "no-colon-here\n"
+      "userUuid: u\n"
+      "deviceUuid: d\n"
+      "privateLicenseKey: K\n";
+  assert(parseCredential(text, &c));
+  assert(c.complete());
+}
+
+// A value containing ": " must not be truncated at the second separator.
+void testValueWithSeparator() {
+  Credential c;
+  const std::string text =
+      "FREEINK-CONTENT-KEY 1\n"
+      "userUuid: u\n"
+      "deviceUuid: d\n"
+      "privateLicenseKey: a: b: c\n";
+  assert(parseCredential(text, &c));
+  assert(c.privateLicenseKey == "a: b: c");
+}
+
+void testByteSource() {
+  MemorySource src{std::string(kValid)};
+  Credential c;
+  assert(parseCredential(src, &c));
+  assert(c.userUuid == "u-123");
+}
+
+// A source reporting a size beyond the bundle cap is refused outright, and one
+// reporting zero never reaches the allocation.
+void testByteSourceSizeGuards() {
+  MemorySource tooBig{std::string(kValid)};
+  tooBig.setSizeOverride(256 * 1024 + 1);
+  Credential c1;
+  assert(!parseCredential(tooBig, &c1));
+
+  MemorySource empty{std::string()};
+  Credential c2;
+  assert(!parseCredential(empty, &c2));
+}
+
+// size() may over-report (short read at EOF); only the bytes actually read are
+// parsed, and the tail of the buffer is never treated as content.
+void testShortRead() {
+  MemorySource src{std::string(kValid)};
+  src.setSizeOverride(std::strlen(kValid) + 4096);
+  Credential c;
+  assert(parseCredential(src, &c));
+  assert(c.privateLicenseKey == "BASE64KEY==");
+}
+
+}  // namespace
+
+int main() {
+  testValid();
+  testCrlfAndBlankLines();
+  testNoTrailingNewline();
+  testRejects();
+  testUnknownFieldsIgnored();
+  testValueWithSeparator();
+  testByteSource();
+  testByteSourceSizeGuards();
+  testShortRead();
+  printf("credential: all tests passed\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Parse credentials over `std::string_view`, slicing in place instead of allocating a `std::string` per line, key, and value.
- Read the bundle into a checked `new (std::nothrow)` buffer, so an unaffordable one returns `false` like every other failure here.
- Clamp the parsed length to the buffer, so a `ByteSource` that over-reports what it read cannot walk past the end.
- Add host tests under `libs/book/ContentProtection/test/host/`.

## Why

`parseCredential()` allocates three heap strings per line. Under `-fno-exceptions` a failed `operator new` calls `abort()` instead of returning, so each is a termination point rather than an error path.

Observed on an ESP32-C3 (CrossPoint fork Matcha Reader custom build with the SD card plugin code changes, ~380KB RAM) with free heap at ~12KB:

```
operator new(unsigned int)
  -> __cxxabiv1::__unexpected -> __assert_func -> panic_abort
std::__cxx11::basic_string::substr
freeink::content::parseCredential(ByteSource&, Credential*)   Credential.cpp:53
```

The device rebooted after the cache of a protected book was cleared. Nothing upstream can recover, because the failure never becomes a return value. After the change the only allocations left are the `Credential`'s own fields.

The clamp is a second commit rather than part of the first: `ByteSource` is implemented by the caller, so `readAt()`'s return is untrusted input. The old `text.resize(n)` absorbed an over-report by growing the string; building a view from `n` directly does not.

## Validation

Behaviour is unchanged: the tests pass **identically against `main`**. They lock the parsing contract so the rewrite is demonstrably equivalent.

- [x] `run.sh` passes on this branch and on `main` — header, CRLF, blank lines, no trailing newline, bad/missing fields, unknown fields, a value containing `": "`, the size cap, and a short read where `size()` over-reports.
- [x] The over-report test fails under AddressSanitizer with the clamp removed (`heap-buffer-overflow`) and passes with it; full suite clean under `-fsanitize=address,undefined`.
- [x] Clean under `-Wall -Wextra -Werror`, and under `-fno-exceptions -fno-rtti` (the config that aborts).
- [x] **On device (ESP32-C3, X4):** regression check for the rewrite. A protected book opens and reads normally — `content accessor open; on-read path active` logs, meaning the new parser read a real credential and the on-read decrypt path engaged — then 55 spine items load, pages render and turn. No errors, no panic.
- [x] **The original abort has not been reproduced after the fix.** It needed ~12KB free heap and fired once, by luck; I could not stage it reliably. The claim is that the throwing allocations are gone, not that I watched the crash stop.

Harness follows the FreeInkBook host tests: `run.sh` plus a self-asserting binary, no framework.

## AI Usage
Diagnosed and fixed by Claude Opus 5 based on a crash report and logs on a X4.
