### PR TITLE
fix: report USB disconnect after storage errors

### DIFF
--- a/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
+++ b/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
@@ -166,11 +166,15 @@ void UsbMassStorage::end() {
 UsbMassStorageState UsbMassStorage::state() const {
   if (!_active) return UsbMassStorageState::Idle;
   const auto current = _state.load();
-  if (current == UsbMassStorageState::Ejected || current == UsbMassStorageState::IoError) return current;
+  if (current == UsbMassStorageState::Ejected) return current;
 
   if (!tud_mounted()) {
     return _hostSeen.load() ? UsbMassStorageState::Disconnected : UsbMassStorageState::WaitingForHost;
   }
+
+  // Keep the error visible while the host is mounted, but report a later cable
+  // removal so the application can safely reclaim its raw storage session.
+  if (current == UsbMassStorageState::IoError) return current;
 
   _hostSeen.store(true);
   auto expected = UsbMassStorageState::WaitingForHost;


### PR DESCRIPTION
## Summary

Fixes USB Mass Storage state reporting after a runtime I/O error.

Previously, if a USB transfer ran into an error (like a failed read/write), the system got stuck permanently showing an "I/O Error" state. Even if you unplugged the USB cable, the firmware never updated to say "Disconnected." Because the app never knew the cable was unplugged, it couldn't safely release or clean up access to the storage drive.

## The Fix
The USB state reporting logic has been updated with clearer rules:
- Host still plugged in + error occurs: Keeps showing the error state (`IoError`) so you know something went wrong.
- Cable unplugged after an error: Switches the state to `Disconnected` as it should.
- User manually ejects the drive: Continues to show `Ejected` as the final state.

## Why
This ensures the system always knows when a cable has actually been unplugged, even after a crash or glitch—allowing the software to safely close out the drive session without freezing or leaking memory.

## Hardware test plan

1. Start USB Mass Storage and connect a host.
2. Trigger or simulate an MSC I/O error.
3. Confirm the error remains reported while the host stays connected.
4. Disconnect the USB cable.
5. Confirm `UsbMassStorage::state()` reports `Disconnected`.