### PR TITLE
fix: bind a drag when its contact begins, not on the tap edge

### DIFF
--- a/libs/ui/FreeInkUI/include/FreeInkUICore.h
+++ b/libs/ui/FreeInkUI/include/FreeInkUICore.h
@@ -1160,6 +1160,8 @@ private:
   // they don't have the torn-read hazard count_/interactions_ have.
   int16_t focused_ = -1;
   int16_t active_ = -1;
+  // Mirrors the last routed frame's contact, so its opening frame is visible.
+  bool contactHeld_ = false;
   ActionId flashAction_ = NO_ACTION; // tap-flash target (see setFlash)
   int16_t flashValue_ = 0;
 
@@ -1191,6 +1193,20 @@ private:
           kind != InputLongPress &&
           acceptsInput(interaction.inputMask, InputTouch);
       if (!acceptsKind && !acceptsTouchFallback)
+        continue;
+      if (interaction.rect.contains(x, y))
+        return i;
+    }
+    return -1;
+  }
+
+  int16_t findDrag(uint8_t slot, int16_t x, int16_t y) const {
+    const Interaction *interactions = interactions_[slot];
+    for (int16_t i = static_cast<int16_t>(count_[slot]) - 1; i >= 0; --i) {
+      const Interaction &interaction = interactions[i];
+      if (hasState(interaction.state, StateDisabled))
+        continue;
+      if (!acceptsInput(interaction.inputMask, InputDrag))
         continue;
       if (interaction.rect.contains(x, y))
         return i;
@@ -1246,6 +1262,16 @@ private:
 
     if (input.touchPressed) {
       active_ = findTouch(slot, input.touchX, input.touchY, InputTouch);
+    }
+
+    // touchPressed is gated on the contact first reading as a tap, which a
+    // fast drag never is. Bind on the frame the contact begins, at the point
+    // it landed — the live position would let a passing contact grab a
+    // slider. Drag-masked elements only, so taps keep press-then-release.
+    const bool contactBegan = input.touchHeld && !contactHeld_;
+    contactHeld_ = input.touchHeld;
+    if (contactBegan && active_ < 0) {
+      active_ = findDrag(slot, input.touchX, input.touchY);
     }
 
     // Grab semantics: a drag stays bound to the element the finger landed on

--- a/libs/ui/FreeInkUI/include/FreeInkUICore.h
+++ b/libs/ui/FreeInkUI/include/FreeInkUICore.h
@@ -1189,24 +1189,12 @@ private:
       if (hasState(interaction.state, StateDisabled))
         continue;
       const bool acceptsKind = acceptsInput(interaction.inputMask, kind);
+      // InputTouch is the catch-all for tap-style kinds; long-press and drag
+      // are opt-in, so a plain button never absorbs them.
       const bool acceptsTouchFallback =
-          kind != InputLongPress &&
+          kind != InputLongPress && kind != InputDrag &&
           acceptsInput(interaction.inputMask, InputTouch);
       if (!acceptsKind && !acceptsTouchFallback)
-        continue;
-      if (interaction.rect.contains(x, y))
-        return i;
-    }
-    return -1;
-  }
-
-  int16_t findDrag(uint8_t slot, int16_t x, int16_t y) const {
-    const Interaction *interactions = interactions_[slot];
-    for (int16_t i = static_cast<int16_t>(count_[slot]) - 1; i >= 0; --i) {
-      const Interaction &interaction = interactions[i];
-      if (hasState(interaction.state, StateDisabled))
-        continue;
-      if (!acceptsInput(interaction.inputMask, InputDrag))
         continue;
       if (interaction.rect.contains(x, y))
         return i;
@@ -1260,18 +1248,21 @@ private:
     ActionEvent event{};
     const size_t slotCount = count_[slot];
 
-    if (input.touchPressed) {
-      active_ = findTouch(slot, input.touchX, input.touchY, InputTouch);
-    }
-
     // touchPressed is gated on the contact first reading as a tap, which a
     // fast drag never is. Bind on the frame the contact begins, at the point
     // it landed — the live position would let a passing contact grab a
-    // slider. Drag-masked elements only, so taps keep press-then-release.
+    // slider. Drag-masked elements only, so taps keep press-then-release;
+    // a contact starting elsewhere clears whatever the last one bound.
     const bool contactBegan = input.touchHeld && !contactHeld_;
     contactHeld_ = input.touchHeld;
-    if (contactBegan && active_ < 0) {
-      active_ = findDrag(slot, input.touchX, input.touchY);
+    if (contactBegan) {
+      active_ = findTouch(slot, input.touchX, input.touchY, InputDrag);
+    }
+
+    // Runs second so an adapter reporting both edges on one frame keeps its
+    // pressed-element highlight.
+    if (input.touchPressed) {
+      active_ = findTouch(slot, input.touchX, input.touchY, InputTouch);
     }
 
     // Grab semantics: a drag stays bound to the element the finger landed on

--- a/libs/ui/FreeInkUI/include/FreeInkUICore.h
+++ b/libs/ui/FreeInkUI/include/FreeInkUICore.h
@@ -1253,8 +1253,16 @@ private:
     // it landed — the live position would let a passing contact grab a
     // slider. Drag-masked elements only, so taps keep press-then-release;
     // a contact starting elsewhere clears whatever the last one bound.
+    // The latch closes on hold and opens on the release edge, never on the
+    // mere absence of a hold: render() routes a default-constructed snapshot
+    // through this same buffer on every repaint, and a drag repaints every
+    // frame. Clearing on !touchHeld would let that placeholder re-open the
+    // latch between two input frames, making every held frame read as a fresh
+    // contact — the bind below would then re-run against the live position and
+    // drop the drag the moment the finger leaves the rect.
     const bool contactBegan = input.touchHeld && !contactHeld_;
-    contactHeld_ = input.touchHeld;
+    if (input.touchHeld) contactHeld_ = true;
+    if (input.touchReleased) contactHeld_ = false;
     if (contactBegan) {
       active_ = findTouch(slot, input.touchX, input.touchY, InputDrag);
     }

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -356,6 +356,70 @@ void testDisabledSkipsTouch() {
   CHECK(!buffer.route(tap));
 }
 
+void testDragRouting() {
+  InteractionBuffer<8> buffer;
+  // 0: slider, 1: plain button below it.
+  buffer.addInteraction(
+      Interaction{Rect{0, 0, 201, 40}, 1, 0, static_cast<uint16_t>(InputTouch | InputDrag), StateNormal, 0});
+  buffer.addInteraction(Interaction{Rect{0, 40, 100, 40}, 2, 0, InputTouch, StateNormal, 0});
+
+  // A drag that starts moving at once never reads as a tap, so it arrives as
+  // a bare held frame with no press edge.
+  const auto contactAt = [](int16_t x, int16_t y) {
+    InputSnapshot snap;
+    snap.touchHeld = true;
+    snap.touchX = x;
+    snap.touchY = y;
+    return snap;
+  };
+  ActionEvent event = buffer.route(contactAt(100, 20));
+  CHECK_EQ(event.action, 1);
+  CHECK_EQ(event.dragPermille, 500);
+
+  // Grab semantics: later frames follow the finger, even off the rect.
+  const InputSnapshot held = contactAt(260, 300);
+  event = buffer.route(held);
+  CHECK_EQ(event.action, 1);
+  CHECK_EQ(event.dragPermille, 1000);
+
+  InputSnapshot release;
+  release.touchReleased = true;
+  release.touchX = -1;
+  release.touchY = -1;
+  CHECK(!buffer.route(release));
+
+  // The landing point decides, not the live one: a contact beginning off the
+  // slider never grabs it, however far it then travels across it. The button
+  // it landed on is not bound either — InputDrag is not part of the InputTouch
+  // fallback, so activeIndex stays clear.
+  CHECK(!buffer.route(contactAt(50, 60)));
+  CHECK_EQ(buffer.activeIndex(), -1);
+  CHECK(!buffer.route(held));
+  buffer.route(release);
+
+  // Touch-only elements are never bound, so the button keeps its press edge.
+  InputSnapshot press;
+  press.touchPressed = true;
+  press.touchX = 50;
+  press.touchY = 60;
+  CHECK(!buffer.route(press));
+  CHECK_EQ(buffer.activeIndex(), 1);
+  buffer.route(release);
+
+  // A fresh contact rebinds even when the previous one reported no release
+  // (an idle frame is all that separates them).
+  CHECK(buffer.route(contactAt(100, 20)));
+  buffer.route(InputSnapshot{});
+  CHECK(!buffer.route(contactAt(50, 60)));
+  buffer.route(InputSnapshot{});
+
+  // A disabled slider is inert on the contact edge too.
+  buffer.clear();
+  buffer.addInteraction(
+      Interaction{Rect{0, 0, 201, 40}, 1, 0, static_cast<uint16_t>(InputTouch | InputDrag), StateDisabled, 0});
+  CHECK(!buffer.route(contactAt(100, 20)));
+}
+
 void testLongPressRouting() {
   InteractionBuffer<8> buffer;
   buffer.addInteraction(Interaction{Rect{0, 0, 100, 100}, 1, 5,
@@ -3321,6 +3385,7 @@ int main() {
   testTouchRouting();
   testDisabledSkipsTouch();
   testLongPressRouting();
+  testDragRouting();
   testFocusNavigationWrapsAndSkips();
   testConfirmIgnoresStaleFocus();
   testConfirmRespectsInputMask();

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -406,12 +406,21 @@ void testDragRouting() {
   CHECK_EQ(buffer.activeIndex(), 1);
   buffer.route(release);
 
-  // A fresh contact rebinds even when the previous one reported no release
-  // (an idle frame is all that separates them).
+  // A repaint routes a default-constructed snapshot through the same buffer.
+  // It must not end the contact: the drag stays bound across it and keeps
+  // following the finger off the rect.
   CHECK(buffer.route(contactAt(100, 20)));
   buffer.route(InputSnapshot{});
+  ActionEvent stillHeld = buffer.route(contactAt(400, 300));
+  CHECK_EQ(stillHeld.action, 1);
+  CHECK_EQ(stillHeld.dragPermille, 1000);
+  buffer.route(release);
+
+  // The release edge is what opens the latch, so the next contact binds fresh
+  // rather than inheriting what the last one held.
   CHECK(!buffer.route(contactAt(50, 60)));
-  buffer.route(InputSnapshot{});
+  CHECK_EQ(buffer.activeIndex(), -1);
+  buffer.route(release);
 
   // A disabled slider is inert on the contact edge too.
   buffer.clear();


### PR DESCRIPTION
## The problem

On a touch board, dragging a slider only works if the finger pauses before it starts moving. A drag that begins immediately — the natural gesture — does nothing at all: the handle stays put, and nothing happens on release either. Try again, dwell for a moment first, and it drags normally.

Reported against CrossPoint's frontlight panel (brightness and warmth sliders), but nothing there is specific to that screen — it is the shared routing.

## Root cause

`InteractionTable::routeAgainst()` binds a drag to its element only on the press edge:

```cpp
if (input.touchPressed) {
  active_ = findTouch(slot, input.touchX, input.touchY, InputTouch);
}
if (input.touchHeld && active_ >= 0 && ...) {   // needs active_
  dragged.dragPermille = dragPermilleFor(held.rect, input.touchX);
}
```

If `active_` is never set, every held frame is dropped silently.

Consumers derive `touchPressed` from a contact that has *already read as a tap*. In CrossPoint that is `MappedInputManager::wasScreenTouchDown()`: it needs `InputManager::isTouchTapCandidate()` — false once the contact passes the 28 px `TOUCH_TAP_SLOP_PX` — and a hold of at least 90 ms. A finger that starts moving as it lands fails both halves, so the press edge never arrives and the drag is never bound. On release, `wasTouchTap()` fails too (slop exceeded), so the snapshot carries no coordinates and even the tap-to-position path is skipped.

## The fix

Bind on the frame the contact begins as well, hit-testing **where it landed** rather than where it has since travelled to.

The landing point matters: binding against the live position would let a contact that started somewhere else grab a slider just by passing over it, which is a worse bug than the one being fixed. `contactHeld_` mirrors the previous routed frame's contact so the opening frame is recognisable, and nothing rebinds until the contact ends.

`findDrag()` requires the `InputDrag` bit strictly, unlike `findTouch()`, which also matches anything accepting `InputTouch`. Buttons, tiles and list rows are therefore never bound and keep their press-then-release semantics unchanged.

One case this does not cover: a screen appearing while a contact is already down would see its first held frame mid-gesture. It does not arise today — swipes are recognised on release (`InputManager::wasSwipe()` requires `touchReleasedEvent`), so a gesture-opened screen never inherits a live contact. Carrying the real down point in `InputSnapshot` would close it off for good, at the cost of a snapshot field every consumer has to fill.

Exercised in the desktop simulator on an X4 Pro profile, not yet on physical hardware — contact timing there differs, so a check on a real device would be worth having before merge.
