### PR TITLE
fix: simplify error lifecycle when USB mass storage encounters I/O errors

### DIFF
--- a/libs/hardware/UsbMassStorage/include/UsbMassStorage.h
+++ b/libs/hardware/UsbMassStorage/include/UsbMassStorage.h
@@ -35,6 +35,9 @@ class UsbMassStorage {
   bool active() const { return _active; }
   UsbMassStorageState state() const;
   bool hostConnected() const;
+  // Soft-disconnect the USB device from the host. Call from application/task
+  // context, never from an MSC callback; end() still owns final teardown.
+  bool disconnectHost() const;
 
   // Called by the TinyUSB callbacks to publish the most recent host event.
   void markAccessed() const;
@@ -60,6 +63,7 @@ class UsbMassStorage {
   bool active() const { return false; }
   UsbMassStorageState state() const { return UsbMassStorageState::Idle; }
   bool hostConnected() const { return false; }
+  bool disconnectHost() const { return false; }
 };
 }  // namespace freeink
 

--- a/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
+++ b/libs/hardware/UsbMassStorage/src/UsbMassStorage.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 extern "C" bool tud_mounted(void);
+extern "C" bool tud_disconnect(void);
 
 namespace freeink {
 namespace {
@@ -187,6 +188,8 @@ bool UsbMassStorage::hostConnected() const {
   return current == UsbMassStorageState::Connected || current == UsbMassStorageState::Accessed;
 }
 
+bool UsbMassStorage::disconnectHost() const { return _active && tud_disconnect(); }
+
 void UsbMassStorage::markAccessed() const {
   auto current = _state.load();
   while (current != UsbMassStorageState::Ejected && current != UsbMassStorageState::IoError) {
@@ -196,7 +199,10 @@ void UsbMassStorage::markAccessed() const {
 
 void UsbMassStorage::markEjected() const { _state.store(UsbMassStorageState::Ejected); }
 
-void UsbMassStorage::markIoError() const { _state.store(UsbMassStorageState::IoError); }
+void UsbMassStorage::markIoError() const {
+  _hostSeen.store(true);
+  _state.store(UsbMassStorageState::IoError);
+}
 
 }  // namespace freeink
 


### PR DESCRIPTION
## Summary

Previously, runtime errors required the firmware to remain in USB Drive mode and wait indefinitely for the user to unplug the cable. That meant managing:
- An error screen that could remain forever.
- Special button restrictions.
- Power-saving behavior while errored.
- Correctly detecting a later physical unplug.
- The possibility of getting stuck if the host never disconnected cleanly.

With this change, the firmware controls the recovery itself. The computer immediately sees the failed drive disappear, and the activity follows the same established Disconnected cleanup path used for normal cable removal.

## **What is the goal of this PR?**
  * Give USB mass-storage consumers a safe way to remove a failed USB disk from the host.
  * Ensure a cable removal or requested soft disconnect after an I/O error is reported as `Disconnected`, rather than returning to `WaitingForHost`.

## **What changes are included?**
  * Adds `UsbMassStorage::disconnectHost()` for task-context USB soft disconnection.
  * Uses TinyUSB’s public `tud_disconnect()` API while the USB mass-storage session is active.
  * Adds a no-op `false` stub when USB MSC support is disabled.
  * Updates `markIoError()` to latch `_hostSeen` before publishing `IoError`.
  * Keeps MSC callbacks limited to publishing state; teardown remains owned by the application task.

## Additional Context

* `disconnectHost()` must be called from application/task context, not from an MSC read or write callback.
* The intended recovery sequence is:
  1. The MSC callback publishes `IoError` and returns the failed block request.
  2. The application observes `IoError` and calls `disconnectHost()`.
  3. The SDK reports `Disconnected` once TinyUSB is no longer mounted.
  4. The application calls `end()`, releases raw storage ownership, and performs any required remount or reboot.
* `disconnectHost()` only removes the USB device from the host. It does not call `USBMSC::end()`, restore a filesystem mount, or switch the ESP32-S3 PHY to another USB personality.
* `_hostSeen` is a session latch used to distinguish “no host has connected yet” from “a previously connected host has disappeared.” Latching it on an I/O error makes both physical unplug and software disconnect resolve correctly.
* The change adds no heap allocation, persistent state, or cache-format changes.