### PR TITLE
Add opt-in RTL row mirroring to list()

### DIFF
--- a/libs/ui/FreeInkUI/include/components/lists/list.h
+++ b/libs/ui/FreeInkUI/include/components/lists/list.h
@@ -96,6 +96,13 @@ struct ListProps {
   // behind a bezel). -1 = inherit the theme's listScrollInset.
   int16_t scrollIndicatorInset = -1;
   bool centerSingleLine = false;
+  // Mirrors row layout for RTL languages: icon and label move to the
+  // trailing (right) edge, value/toggle move to the leading (left) edge --
+  // matching BaseTheme::drawList()'s "title right, value left" convention.
+  // Callers must set this themselves (I18N.isRtl()); list() has no built-in
+  // language awareness. Off by default so every existing caller is
+  // unaffected.
+  bool rtl = false;
   // Shrink each row's background/hit area to its label width plus side
   // padding instead of the full rect width (hug-content menu rows).
   bool hugContents = false;
@@ -517,26 +524,41 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
                                    ? props.iconSize
                                    : static_cast<int16_t>(icon.width);
       // Centered on the full row content, not the title band: with a subtitle
-      // the icon belongs to the label+subtitle block as a whole.
+      // the icon belongs to the label+subtitle block as a whole. RTL mirrors
+      // the icon to the row's trailing (right) edge, matching
+      // BaseTheme::drawList's "title anchored right" convention, and shrinks
+      // content from that side instead so the label/value slots below
+      // reflow to the left of it.
+      const int16_t iconX = props.rtl
+          ? static_cast<int16_t>(content.x + content.width - iconSize)
+          : content.x;
       Rect iconRect{
-          content.x,
+          iconX,
           static_cast<int16_t>(content.y + (content.height - iconSize) / 2),
           iconSize, iconSize};
       frame.target().bitmap(iconRect, icon, BitmapMode::Contain,
                             style.foreground);
-      content.x = static_cast<int16_t>(content.x + iconSize + props.textGap);
+      if (!props.rtl)
+        content.x = static_cast<int16_t>(content.x + iconSize + props.textGap);
       content.width =
           static_cast<int16_t>(content.width - iconSize - props.textGap);
       band.x = content.x;
       band.width = content.width;
     }
 
+    // RTL: the value/toggle slot moves to the band's leading (left) edge and
+    // the label fills whatever remains on the trailing (right) edge, next to
+    // the icon -- computed below via labelX once the slot width is known.
+    int16_t labelX = band.x;
     int16_t availW = band.width;
     if (item.toggle) {
       const int16_t togW = props.toggleWidth < 18 ? 18 : props.toggleWidth;
       const int16_t togH = props.toggleHeight < 12 ? 12 : props.toggleHeight;
+      const int16_t togX = props.rtl
+          ? static_cast<int16_t>(band.x + props.valueInset)
+          : static_cast<int16_t>(band.x + band.width - togW - props.valueInset);
       Rect toggleRect{
-          static_cast<int16_t>(band.x + band.width - togW - props.valueInset),
+          togX,
           static_cast<int16_t>(band.y + (band.height - togH) / 2), togW, togH};
       // The switch draws in row-foreground ink with the foreground's opposite
       // as "paper", so it inverts along with the row when selected.
@@ -568,20 +590,25 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       }
       availW = static_cast<int16_t>(availW - togW - props.valueInset -
                                     props.textGap);
+      if (props.rtl)
+        labelX = static_cast<int16_t>(band.x + band.width - availW);
     } else if (item.value) {
       TextStyle valueStyle =
           textStyleWithForeground(props.valueText, style.foreground);
-      valueStyle.align = TextAlign::Right;
+      valueStyle.align = props.rtl ? TextAlign::Left : TextAlign::Right;
       const int16_t valueW =
           frame.target()
               .measureText(valueStyle.font, item.value, valueStyle)
               .width;
-      Rect valueRect{
-          static_cast<int16_t>(band.x + availW - valueW - props.valueInset),
-          band.y, valueW, band.height};
+      const int16_t valueX = props.rtl
+          ? static_cast<int16_t>(band.x + props.valueInset)
+          : static_cast<int16_t>(band.x + availW - valueW - props.valueInset);
+      Rect valueRect{valueX, band.y, valueW, band.height};
       frame.target().text(valueRect, item.value, valueStyle);
       availW = static_cast<int16_t>(availW - valueW - props.valueInset -
                                     props.textGap);
+      if (props.rtl)
+        labelX = static_cast<int16_t>(band.x + band.width - availW);
     }
 
     if (props.balanceWrappedLabelWithValue && labelStyle.maxLines > 1 && (item.toggle || item.value) && item.label) {
@@ -599,8 +626,10 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       }
     }
 
+    if (props.rtl && !props.centerSingleLine)
+      labelStyle.align = TextAlign::Right;
     if (item.subtitle) {
-      frame.target().text(Rect{band.x, band.y, availW, band.height}, item.label,
+      frame.target().text(Rect{labelX, band.y, availW, band.height}, item.label,
                           labelStyle);
       frame.target().text(
           Rect{content.x, static_cast<int16_t>(band.y + band.height),
@@ -610,15 +639,20 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
     } else {
       if (props.centerSingleLine)
         labelStyle.align = TextAlign::Center;
-      frame.target().text(Rect{band.x, band.y, availW, band.height}, item.label,
+      frame.target().text(Rect{labelX, band.y, availW, band.height}, item.label,
                           labelStyle);
     }
 
     if (props.selectedIndex == static_cast<int16_t>(i) &&
         props.selectionMarker != SelectionMarker::None) {
       if (props.selectionMarker == SelectionMarker::Underline) {
+        // RTL mirrors which edge carries markerInset's extra gap, matching
+        // the label's own trailing/leading swap above.
+        const int16_t underlineX = props.rtl
+            ? static_cast<int16_t>(row.x + sidePad)
+            : static_cast<int16_t>(row.x + sidePad + props.markerInset);
         frame.target().fill(
-            Rect{static_cast<int16_t>(row.x + sidePad + props.markerInset),
+            Rect{underlineX,
                  static_cast<int16_t>(row.bottom() - props.markerThickness),
                  static_cast<int16_t>(row.width - sidePad * 2 -
                                       props.markerInset),

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -807,6 +807,109 @@ void testListCanUseFullTitleWidthWithShortValue() {
   CHECK_EQ(fullWidthDraw.ops[2].rect.width, 424);
 }
 
+// RTL mirrors list()'s row layout: icon and label move to the trailing
+// (right) edge, value/toggle move to the leading (left) edge. Verifies both
+// halves of the swap against the same single-row fixture in one pass.
+void testListRtlMirrorsIconAndValueSides() {
+  static const uint8_t iconBits[4] = {0, 0, 0, 0};
+  BitmapRef icon{iconBits, 16, 16, BitmapFormat::BW1, false};
+
+  ListItem item{};
+  item.label = "Setting";
+  item.value = "On";
+  item.icon = icon;
+
+  ListProps props;
+  props.items = &item;
+  props.count = 1;
+  props.rowHeight = 40;
+  props.valueInset = 4;
+  props.sidePadding = 0;  // zero out the default 8px inset so row math below is exact
+
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+
+  FakeDrawTarget ltrDraw;
+  InteractionBuffer<4> ltrInteractions;
+  Frame<4> ltrFrame(ltrDraw, device, input, ltrInteractions);
+  list(ltrFrame, Rect{0, 0, 480, 40}, props);
+
+  props.rtl = true;
+  FakeDrawTarget rtlDraw;
+  InteractionBuffer<4> rtlInteractions;
+  Frame<4> rtlFrame(rtlDraw, device, input, rtlInteractions);
+  list(rtlFrame, Rect{0, 0, 480, 40}, props);
+
+  // Icon: LTR hugs the row's left edge; RTL hugs the right edge.
+  size_t ltrIconIdx = 0, rtlIconIdx = 0;
+  for (size_t i = 0; i < ltrDraw.opCount; ++i)
+    if (ltrDraw.ops[i].kind == FakeDrawTarget::Op::Bitmap) ltrIconIdx = i;
+  for (size_t i = 0; i < rtlDraw.opCount; ++i)
+    if (rtlDraw.ops[i].kind == FakeDrawTarget::Op::Bitmap) rtlIconIdx = i;
+  CHECK_EQ(ltrDraw.ops[ltrIconIdx].rect.x, 0);
+  CHECK_EQ(rtlDraw.ops[rtlIconIdx].rect.x, 480 - 16);
+
+  // Value text: list() draws the value slot before the label, so the FIRST
+  // Text op is the value, not the last. LTR sits near the row's right edge;
+  // RTL sits near the left, just past the icon-free band start
+  // (band.x + valueInset).
+  size_t ltrValueIdx = 0, rtlValueIdx = 0;
+  for (size_t i = 0; i < ltrDraw.opCount; ++i) {
+    if (ltrDraw.ops[i].kind == FakeDrawTarget::Op::Text) {
+      ltrValueIdx = i;
+      break;
+    }
+  }
+  for (size_t i = 0; i < rtlDraw.opCount; ++i) {
+    if (rtlDraw.ops[i].kind == FakeDrawTarget::Op::Text) {
+      rtlValueIdx = i;
+      break;
+    }
+  }
+  CHECK(ltrDraw.ops[ltrValueIdx].rect.x > 400);  // right side in LTR
+  CHECK_EQ(rtlDraw.ops[rtlValueIdx].rect.x, 4);  // band.x(0) + valueInset(4) in RTL
+}
+
+// Same swap, but for a toggle row instead of a value row: the switch itself
+// (not just its knob) must relocate, since activateSelectedRow-style callers
+// rely on the toggle's on-screen position matching its touch hit region.
+void testListRtlMirrorsToggleSide() {
+  ListItem item{};
+  item.label = "Enabled";
+  item.toggle = true;
+  item.toggleChecked = true;
+
+  ListProps props;
+  props.items = &item;
+  props.count = 1;
+  props.rowHeight = 40;
+  props.valueInset = 4;
+  props.toggleWidth = 38;
+  props.sidePadding = 0;  // zero out the default 8px inset so row math below is exact
+
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+
+  FakeDrawTarget ltrDraw;
+  InteractionBuffer<4> ltrInteractions;
+  Frame<4> ltrFrame(ltrDraw, device, input, ltrInteractions);
+  list(ltrFrame, Rect{0, 0, 480, 40}, props);
+
+  props.rtl = true;
+  FakeDrawTarget rtlDraw;
+  InteractionBuffer<4> rtlInteractions;
+  Frame<4> rtlFrame(rtlDraw, device, input, rtlInteractions);
+  list(rtlFrame, Rect{0, 0, 480, 40}, props);
+
+  // The toggle track is the first Fill after the row background fill.
+  CHECK(ltrDraw.opCount >= 2);
+  CHECK(rtlDraw.opCount >= 2);
+  CHECK_EQ(ltrDraw.ops[1].kind, FakeDrawTarget::Op::Fill);
+  CHECK_EQ(rtlDraw.ops[1].kind, FakeDrawTarget::Op::Fill);
+  CHECK_EQ(ltrDraw.ops[1].rect.x, 480 - 38 - 4);  // right edge in LTR
+  CHECK_EQ(rtlDraw.ops[1].rect.x, 4);             // left edge (band.x + valueInset) in RTL
+}
+
 void testButtonRegistersExpandedHit() {
   FakeDrawTarget draw;
   DeviceContext device = makeDevice();
@@ -3044,6 +3147,8 @@ int main() {
   testListNavLayoutFeedback();
   testListNavConvergesThroughRealList();
   testListCanUseFullTitleWidthWithShortValue();
+  testListRtlMirrorsIconAndValueSides();
+  testListRtlMirrorsToggleSide();
   testButtonRegistersExpandedHit();
   testProgressBarClamps();
   testBatteryIndicator();


### PR DESCRIPTION
## Summary

`list()` (`libs/ui/FreeInkUI/include/components/lists/list.h`) hardcodes an LTR row layout — icon on the left, value/toggle on the right, label anchored left — with no language awareness. `BaseTheme`'s own `drawList()` in the consuming Midad firmware already mirrors this for RTL languages (title right, value left), but `list()` had no equivalent, so an RTL-aware screen built on it had no way to get correct layout without duplicating the row math outside the component.

This adds `ListProps::rtl` (default `false`, so every existing caller is unaffected) and mirrors:
- the icon position (right edge instead of left)
- the value/toggle slot position (left edge instead of right)
- the label's remaining band and text alignment
- the underline selection marker's inset side

Callers own detecting their own RTL state (e.g. `I18N.isRtl()` in Midad) — `list()` itself stays language-unaware, matching the existing pattern where each theme override owns its own draw math.

## Test plan
- [x] `libs/ui/FreeInkUI/test/host/run.sh` — 2707 checks run, only the 3 pre-existing failures unrelated to `list()` remain (confirmed identical on the unmodified base commit via `git stash`)
- [x] Two new host tests added, exercising the real `list()` renderer via the existing `FakeDrawTarget` fixture:
  - `testListRtlMirrorsIconAndValueSides` — icon and value slot swap sides
  - `testListRtlMirrorsToggleSide` — toggle row swap