### PR TITLE
Add LM3630A I2C frontlight driver for EGO Reader A4

### DIFF
--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -570,6 +570,23 @@ struct FrontlightConfig {
   int8_t i2cEnableGpio = PIN_UNASSIGNED;  // chip power/enable, active-high (EEGO: GPIO12)
 };
 
+// I2C frontlight controller (LM3630A on the EEGO A4). The controller is driven
+// over a board I2C bus with a separate enable GPIO; the enable is also the
+// hardware probe: an unpopulated optional circuit (some retail A4 units ship
+// without a frontlight) never ACKs, so FrontlightManager only reports present()
+// after a successful probe.
+enum class I2cFrontlightController : uint8_t { None, Lm3630a };
+struct I2cFrontlightConfig {
+  I2cFrontlightController controller;
+  int8_t sda;
+  int8_t scl;
+  uint32_t i2cHz;
+  uint8_t address;
+  int8_t enable;
+};
+constexpr I2cFrontlightConfig NO_I2C_FRONTLIGHT = {I2cFrontlightController::None, PIN_UNASSIGNED, PIN_UNASSIGNED, 0,
+                                                   0, PIN_UNASSIGNED};
+
 // Audio output description (AudioOutput::None disables it).
 struct AudioConfig {
   AudioOutput output;
@@ -714,6 +731,9 @@ struct BoardProfile {
   // no pull (the X4 Pro's GPIO21, recovered from the stock Cw2017PowerHal —
   // stock configures it input/no-pull and reports the raw level).
   bool batteryChargeStatusActiveHigh = false;
+  // I2C frontlight (LM3630A). Defaulted so existing profiles need no change;
+  // a board with one sets it (EEGO A4).
+  I2cFrontlightConfig i2cFrontlight = NO_I2C_FRONTLIGHT;
 };
 
 constexpr TouchConfig NO_TOUCH = {TouchController::None,
@@ -1383,7 +1403,10 @@ constexpr BoardProfile EEGO_A4 = {
     // Charger STAT GPIO11 is driven HIGH while charging, like the X4 Pro
     // (hardware verified: with the active-low default the charging indicator
     // lit only when USB was unplugged).
-    true};
+    true,
+    // LM3630A on the shared I2C bus (SDA2/SCL1), enable GPIO12.
+    // Probed at runtime: some retail A4 units have no frontlight.
+    {I2cFrontlightController::Lm3630a, 2, 1, 400000, 0x36, 12}};
 
 static_assert(EEGO_A4.displayWidth / 8 * EEGO_A4.displayHeight == 52992,
               "EEGO A4 framebuffer must be 52,992 bytes (768/8 x 552)");
@@ -1755,6 +1778,11 @@ inline bool isEegoA4() { return ACTIVE.board == Board::EegoA4; }
 inline bool hasTouch() { return ACTIVE.touch.controller != TouchController::None; }
 inline bool hasHomeKey() { return ACTIVE.touch.hasHomeKey; }
 inline bool hasPwmFrontlight() { return ACTIVE.frontlight.gpio != PIN_UNASSIGNED || ACTIVE.frontlight.viaPm1Pwm; }
+inline bool hasI2cFrontlight() { return ACTIVE.i2cFrontlight.controller != I2cFrontlightController::None; }
+inline bool hasColorTemperatureFrontlight() {
+  return (ACTIVE.frontlight.gpio != PIN_UNASSIGNED && ACTIVE.frontlight.gpioWarm != PIN_UNASSIGNED) ||
+         ACTIVE.i2cFrontlight.controller == I2cFrontlightController::Lm3630a;
+}
 inline bool hasAudio() { return ACTIVE.audio.output != AudioOutput::None; }
 
 // Safety guard: a power-latch pin must never coincide with a display or SDMMC

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -41,11 +41,14 @@ class FrontlightManager {
 
   bool present() const {
 #if FREEINK_CAP_FRONTLIGHT
-    // A PMIC-driven frontlight (Paper Mono: PM1 PWM0 -> AW9967) or an I2C LED
-    // driver (EEGO A4: chip at 0x36) has no ESP LEDC pin, so those flags count as
-    // present alongside the LEDC-pin boards.
+    // A PMIC-driven frontlight (Paper Mono: PM1 PWM0 -> AW9967) has no ESP
+#if FREEINK_DEVICE_EEGO_A4
+    // An optional EEGO A4 LM3630A is present only after begin() gets an ACK.
+    if (BoardConfig::ACTIVE.board == BoardConfig::Board::EegoA4 && BoardConfig::hasI2cFrontlight()) return _begun;
+#endif
+    // GPIO, so viaPm1Pwm counts as present alongside the LEDC-pin boards.
     return BoardConfig::ACTIVE.frontlight.gpio != BoardConfig::PIN_UNASSIGNED ||
-           BoardConfig::ACTIVE.frontlight.viaPm1Pwm || BoardConfig::ACTIVE.frontlight.viaI2cLed;
+           BoardConfig::ACTIVE.frontlight.viaPm1Pwm;
 #else
     return false;  // frontlight code not compiled in (FREEINK_CAP_FRONTLIGHT=0)
 #endif
@@ -54,10 +57,14 @@ class FrontlightManager {
   // True when the board wires a second (warm) channel, so setColorTemperature() does
   // something. False on single-channel frontlights and on boards with none.
   bool hasColorTemperature() const {
+#if FREEINK_DEVICE_EEGO_A4 && FREEINK_CAP_FRONTLIGHT
+    if (BoardConfig::ACTIVE.board == BoardConfig::Board::EegoA4) {
+      return present() && BoardConfig::hasColorTemperatureFrontlight();
+    }
+#endif
 #if FREEINK_CAP_WARMLIGHT
-    const auto& fl = BoardConfig::ACTIVE.frontlight;
-    if (fl.viaI2cLed) return fl.i2cRegWarm != 0 && fl.i2cRegCool != 0;  // warm/cool on separate regs
-    return fl.gpio != BoardConfig::PIN_UNASSIGNED && fl.gpioWarm != BoardConfig::PIN_UNASSIGNED;
+    return BoardConfig::ACTIVE.frontlight.gpio != BoardConfig::PIN_UNASSIGNED &&
+           BoardConfig::ACTIVE.frontlight.gpioWarm != BoardConfig::PIN_UNASSIGNED;
 #else
     return false;  // no warm-channel board in this build (FREEINK_CAP_WARMLIGHT=0)
 #endif
@@ -71,6 +78,14 @@ class FrontlightManager {
 #if FREEINK_CAP_FRONTLIGHT
   // Recompute and write both channels from _brightness + _warmPercent.
   void apply();
+#if FREEINK_DEVICE_EEGO_A4
+  // LM3630A (I2C) frontlight helpers — see FrontlightManager.cpp.
+  bool lm3630aWrite(uint8_t reg, uint8_t value);
+  bool lm3630aRead(uint8_t reg, uint8_t& value);
+  bool lm3630aUpdate(uint8_t reg, uint8_t mask, uint8_t value);
+  bool configureLm3630a();
+  void applyLm3630a();
+#endif
 #endif
 #ifdef FREEINK_FRONTLIGHT_LS
   // Keep RC_FAST powered through light sleep only while the light is actually
@@ -85,6 +100,9 @@ class FrontlightManager {
 #endif
 
   bool _begun = false;
+#if FREEINK_DEVICE_EEGO_A4
+  bool _i2cConfigured = false;
+#endif
   uint8_t _brightness = 0;
   uint8_t _brightnessLevel = 0;
   bool _useLevel = false;

--- a/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
+++ b/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
@@ -58,38 +58,6 @@ void pm1FrontlightWrite(uint32_t pct) {
   freeink::m5pm1::writeBytes(freeink::m5pm1::REG_PWM0_DUTY_L, data, sizeof(data));
 }
 
-// EEGO A4 (frontlit variant): a dual-channel white-LED driver chip on the shared
-// I2C bus (same wires as touch/RTC), powered by an enable GPIO. Cool and warm
-// brightness are separate registers; the total is clamped to i2cMaxTotal. The init
-// register sequence below is what the stock firmware writes (charge-pump / current
-// limits) — recovered by RE, so it may want tuning against a physical unit.
-struct I2cLedReg {
-  uint8_t reg;
-  uint8_t val;
-};
-constexpr I2cLedReg kI2cLedInit[] = {
-    {0x50, 0x03}, {0x01, 0x07}, {0x02, 0x38}, {0x05, 0x1F}, {0x06, 0x1F},
-};
-
-void i2cLedWriteReg(const BoardConfig::FrontlightConfig& fl, uint8_t reg, uint8_t val) {
-  Wire.beginTransmission(fl.i2cAddr);
-  Wire.write(reg);
-  Wire.write(val);
-  Wire.endTransmission();
-}
-
-void i2cLedAttach(const BoardConfig::FrontlightConfig& fl) {
-  if (fl.i2cEnableGpio != BoardConfig::PIN_UNASSIGNED) {
-    pinMode(fl.i2cEnableGpio, OUTPUT);
-    digitalWrite(fl.i2cEnableGpio, HIGH);  // active-high chip power
-    delay(2);
-  }
-  if (fl.i2cSda != BoardConfig::PIN_UNASSIGNED && fl.i2cScl != BoardConfig::PIN_UNASSIGNED) {
-    Wire.begin(fl.i2cSda, fl.i2cScl);  // shared bus; idempotent if touch/RTC already brought it up
-  }
-  for (const auto& r : kI2cLedInit) i2cLedWriteReg(fl, r.reg, r.val);
-}
-
 // Fixed LEDC channels for the Arduino-ESP32 2.x path (3.x keys by GPIO and allocates
 // channels itself). Frontlight owns 0 (cool/primary) and 1 (warm); no other SDK LEDC
 // user on a frontlight board takes these (the Buzzer uses the 3.x gpio-keyed API).
@@ -160,14 +128,34 @@ void writeChannel(int8_t /*gpio*/, uint8_t ch, uint32_t duty) { ledcWrite(ch, du
 void FrontlightManager::begin() {
 #if FREEINK_CAP_FRONTLIGHT
   const auto& fl = BoardConfig::ACTIVE.frontlight;
-  if (fl.viaPm1Pwm) {
-    pm1FrontlightAttach(fl.pwmFrequency);
+#if FREEINK_DEVICE_EEGO_A4
+  const auto& i2c = BoardConfig::ACTIVE.i2cFrontlight;
+  if (BoardConfig::ACTIVE.board == BoardConfig::Board::EegoA4 &&
+      i2c.controller == BoardConfig::I2cFrontlightController::Lm3630a) {
+    if (i2c.sda < 0 || i2c.scl < 0 || i2c.enable < 0 || i2c.address == 0) return;
+    Wire.begin(i2c.sda, i2c.scl, i2c.i2cHz);
+    Wire.setTimeOut(256);
+    pinMode(i2c.enable, OUTPUT);
+    digitalWrite(i2c.enable, LOW);
+
+    // The OEM firmware contains an LM3630A path, but at least one retail EEGO
+    // A4 revision has no frontlight hardware populated. Probe with the recovered
+    // enable sequence so an absent option stays off and is not exposed as a
+    // capability merely because its driver exists in a shared firmware image.
+    digitalWrite(i2c.enable, HIGH);
+    delay(2);
+    Wire.beginTransmission(i2c.address);
+    const bool detected = Wire.endTransmission() == 0;
+    digitalWrite(i2c.enable, LOW);
+    if (!detected) return;
+
     _begun = true;
-    setBrightness(0);
+    _brightness = 0;
     return;
   }
-  if (fl.viaI2cLed) {
-    i2cLedAttach(fl);
+#endif
+  if (fl.viaPm1Pwm) {
+    pm1FrontlightAttach(fl.pwmFrequency);
     _begun = true;
     setBrightness(0);
     return;
@@ -202,28 +190,100 @@ void FrontlightManager::begin() {
 }
 
 #if FREEINK_CAP_FRONTLIGHT
+#if FREEINK_DEVICE_EEGO_A4
+bool FrontlightManager::lm3630aWrite(const uint8_t reg, const uint8_t value) {
+  const auto& cfg = BoardConfig::ACTIVE.i2cFrontlight;
+  Wire.beginTransmission(cfg.address);
+  Wire.write(reg);
+  Wire.write(value);
+  return Wire.endTransmission() == 0;
+}
+
+bool FrontlightManager::lm3630aRead(const uint8_t reg, uint8_t& value) {
+  const auto& cfg = BoardConfig::ACTIVE.i2cFrontlight;
+  Wire.beginTransmission(cfg.address);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) return false;
+  if (Wire.requestFrom(cfg.address, static_cast<uint8_t>(1), static_cast<uint8_t>(true)) != 1) return false;
+  value = Wire.read();
+  return true;
+}
+
+bool FrontlightManager::lm3630aUpdate(const uint8_t reg, const uint8_t mask, const uint8_t value) {
+  uint8_t current = 0;
+  if (!lm3630aRead(reg, current)) return false;
+  return lm3630aWrite(reg, static_cast<uint8_t>((current & ~mask) | (value & mask)));
+}
+
+bool FrontlightManager::configureLm3630a() {
+  const auto& cfg = BoardConfig::ACTIVE.i2cFrontlight;
+  digitalWrite(cfg.enable, HIGH);
+  delay(2);
+  Wire.beginTransmission(cfg.address);
+  if (Wire.endTransmission() != 0) {
+    digitalWrite(cfg.enable, LOW);
+    return false;
+  }
+
+  // Exact EEGO A4 sequence recovered from HalBacklight/LM3630A in CrossLink.
+  // Register meanings follow TI SNVS974B: filter, config, boost, max-current A/B,
+  // control, then the two brightness banks.
+  bool ok = lm3630aWrite(0x50, 0x03);
+  ok = lm3630aUpdate(0x01, 0x07, 0x00) && ok;
+  ok = lm3630aWrite(0x02, 0x38) && ok;
+  ok = lm3630aUpdate(0x05, 0x1f, 0x10) && ok;
+  ok = lm3630aUpdate(0x06, 0x1f, 0x10) && ok;
+  ok = lm3630aUpdate(0x00, 0x14, 0x00) && ok;
+  ok = lm3630aUpdate(0x00, 0x0b, 0x00) && ok;
+  delay(2);
+  ok = lm3630aWrite(0x03, 0x00) && ok;
+  ok = lm3630aWrite(0x04, 0x00) && ok;
+  _i2cConfigured = ok;
+  if (!ok) digitalWrite(cfg.enable, LOW);
+  return ok;
+}
+
+void FrontlightManager::applyLm3630a() {
+  const auto& cfg = BoardConfig::ACTIVE.i2cFrontlight;
+  if (_brightness == 0) {
+    if (_i2cConfigured) {
+      lm3630aWrite(0x03, 0);
+      lm3630aWrite(0x04, 0);
+    }
+    digitalWrite(cfg.enable, LOW);
+    _i2cConfigured = false;
+    return;
+  }
+  if (!_i2cConfigured && !configureLm3630a()) return;
+
+  const uint8_t level = static_cast<uint16_t>(_brightness) * 255 / 100;
+  uint8_t warm = static_cast<uint16_t>(level) * _warmPercent / 100;
+  uint8_t cool = static_cast<uint16_t>(level) * (100 - _warmPercent) / 100;
+  // The IC ignores brightness codes 1..3; preserve a visible nonzero request.
+  if (warm != 0 && warm < 4) warm = 4;
+  if (cool != 0 && cool < 4) cool = 4;
+
+  lm3630aUpdate(0x00, 0x80, 0x00);  // leave software sleep
+  delay(2);
+  lm3630aWrite(0x03, warm);
+  lm3630aWrite(0x04, cool);
+  lm3630aUpdate(0x00, 0x04, warm >= 4 ? 0x04 : 0x00);
+  lm3630aUpdate(0x00, 0x02, cool >= 4 ? 0x02 : 0x00);
+}
+#endif
+
 void FrontlightManager::apply() {
   const auto& fl = BoardConfig::ACTIVE.frontlight;
   if (!_begun) return;
-  if (fl.viaPm1Pwm) {
-    pm1FrontlightWrite(_brightness);
+#if FREEINK_DEVICE_EEGO_A4
+  if (BoardConfig::ACTIVE.board == BoardConfig::Board::EegoA4 &&
+      BoardConfig::ACTIVE.i2cFrontlight.controller == BoardConfig::I2cFrontlightController::Lm3630a) {
+    applyLm3630a();
     return;
   }
-  if (fl.viaI2cLed) {
-    // Total brightness maps onto the chip's 0..i2cMaxTotal range, then splits into
-    // cool + warm by color temperature (so cool+warm == total <= max).
-    const uint32_t full = fl.i2cMaxTotal ? fl.i2cMaxTotal : 255u;
-    uint32_t total = 0;
-    if (_useLevel && _brightnessLevel > 0) {
-      const uint32_t n = static_cast<uint32_t>(_brightnessLevel - 1u);
-      total = 1u + (n * n * (full - 1u)) / (254u * 254u);
-    } else if (!_useLevel) {
-      total = (static_cast<uint32_t>(_brightness) * full + 50u) / 100u;
-    }
-    const uint32_t warm = (total * _warmPercent + 50u) / 100u;
-    const uint32_t cool = total - warm;
-    i2cLedWriteReg(fl, fl.i2cRegCool, static_cast<uint8_t>(cool));
-    i2cLedWriteReg(fl, fl.i2cRegWarm, static_cast<uint8_t>(warm));
+#endif
+  if (fl.viaPm1Pwm) {
+    pm1FrontlightWrite(_brightness);
     return;
   }
   if (fl.gpio == BoardConfig::PIN_UNASSIGNED) return;


### PR DESCRIPTION
Adds the LM3630A I2C backlight driver for the EEGO Reader A4 (ESP32-S3 N16R8). This mirrors the hardware-validated implementation from the crossmux fork: a dedicated LM3630A path (probe, init sequence, software-sleep exit, warm/cool brightness banks) that replaces the generic viaI2cLed path which never enabled the output channels.

- BoardConfig: adds I2cFrontlightController/I2cFrontlightConfig, the i2cFrontlight BoardProfile field, and hasI2cFrontlight()/hasColorTemperatureFrontlight() helpers.
- FrontlightManager: probes the LM3630A at begin() via the enable GPIO + I2C ACK, runs the exact OEM-recovered init sequence, exits software sleep, and drives warm/cool banks (brightness codes clamped 1-3 to 4).