### PR TITLE
fix(x4pro): always park EPD panel before deep sleep

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
@@ -389,7 +389,9 @@ void Ssd1677Driver::powerOn(EpdBus& bus) {
 void Ssd1677Driver::powerOffController(EpdBus& bus) {
   // Always park: re-issuing the border/analog-off sequence on an already-off
   // panel is harmless, and this guarantees the booster is off before DSLP even
-  // if _isScreenOn drifted out of sync (see the AA-pass desync above).
+  // if _isScreenOn drifted out of sync (see the AA-pass desync above). This
+  // driver is ActiveHigh (Ssd1677Driver.h), whose waitBusy() has a 30 s ceiling
+  // (EpdBus.cpp:225), so an off panel cannot hang here.
   bus.cmd(CMD_BORDER_WAVEFORM);
   bus.data(_cfg.borderWaveformInit);  // X4 Pro: 0x80
   bus.cmd(CMD_DISPLAY_UPDATE_CTRL2);

--- a/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
@@ -354,8 +354,15 @@ void Ssd1677Driver::refresh(EpdBus& bus, RefreshMode mode, bool turnOff, bool as
     // not, so 0xCC is correct in both states. The production driver marks power OFF
     // after this pass; mirror that so the next refresh re-enables the rails.
     displayMode = 0xCC;
-    if (turnOff) displayMode |= 0x03;
-    _isScreenOn = false;
+    // Only mark the screen off when the activation actually powered it down. A
+    // custom-LUT/AA pass with turnOff==false leaves the rails ON (0xCC keeps
+    // CLOCK/ANALOG enabled); flipping the flag false here desyncs it from the
+    // real rail state and lets deepSleep() skip the booster-off sequence,
+    // leaving the charge-pump biased while PR #3215 holds the master rail up.
+    if (turnOff) {
+      displayMode |= 0x03;
+      _isScreenOn = false;
+    }
   } else {  // Fast
     displayMode |= 0x1C;
   }
@@ -380,7 +387,9 @@ void Ssd1677Driver::powerOn(EpdBus& bus) {
 }
 
 void Ssd1677Driver::powerOffController(EpdBus& bus) {
-  if (!_isScreenOn) return;
+  // Always park: re-issuing the border/analog-off sequence on an already-off
+  // panel is harmless, and this guarantees the booster is off before DSLP even
+  // if _isScreenOn drifted out of sync (see the AA-pass desync above).
   bus.cmd(CMD_BORDER_WAVEFORM);
   bus.data(_cfg.borderWaveformInit);  // X4 Pro: 0x80
   bus.cmd(CMD_DISPLAY_UPDATE_CTRL2);

--- a/libs/display/FreeInkDisplay/src/driver/Uc8179Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8179Driver.cpp
@@ -398,8 +398,20 @@ void Uc8179Driver::deepSleep(EpdBus& bus) {
   // _isScreenOn drifted out of sync. PR #3215 holds the X4 Pro master rail
   // (GPIO1) HIGH through deep sleep, so a biased booster would otherwise keep
   // drawing mA.
+  //
+  // Wait only when the panel was actually on. This driver's busy polarity is
+  // UcIdleHigh (Uc8179Driver.h), whose waitBusy() has NO millisecond timeout
+  // (EpdBus.cpp:251-267) — issuing the next command while BUSY_N stays LOW can
+  // make the controller discard writes. That is safe here: on the X4 Pro the
+  // panel rail is always powered (display.powerEnable = PIN_UNASSIGNED, so
+  // powerDownRailsForSleep() never gates it), so a panel that was on reads
+  // BUSY HIGH (idle) and POF completes immediately; and the stuck-LOW case
+  // (rail dropped -> BUSY floated LOW) belonged to the PRE-#3215 battery-only
+  // bug, which PR #3215 removed by holding the master rail up. Skipping the
+  // wait on an already-off panel avoids an unbounded busy-poll with no real
+  // work to wait for.
   bus.cmd(CMD_POWER_OFF);
-  bus.waitBusy(" 8179 power-down");
+  if (_isScreenOn) bus.waitBusy(" 8179 power-down");
   _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);

--- a/libs/display/FreeInkDisplay/src/driver/Uc8179Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8179Driver.cpp
@@ -393,11 +393,14 @@ void Uc8179Driver::skipInitialResync() { _needFullClear = false; }
 void Uc8179Driver::deepSleep(EpdBus& bus) {
   _grayBaseValid = false;
   _absoluteGrayPlanes = false;
-  if (_isScreenOn) {
-    bus.cmd(CMD_POWER_OFF);
-    bus.waitBusy(" 8179 power-down");
-    _isScreenOn = false;
-  }
+  // Always power the panel down before DSLP: re-issuing POF on an already-off
+  // panel is harmless, and guarantees the booster/charge-pump is off even if
+  // _isScreenOn drifted out of sync. PR #3215 holds the X4 Pro master rail
+  // (GPIO1) HIGH through deep sleep, so a biased booster would otherwise keep
+  // drawing mA.
+  bus.cmd(CMD_POWER_OFF);
+  bus.waitBusy(" 8179 power-down");
+  _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);
 }

--- a/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
@@ -221,11 +221,10 @@ void Uc8279Driver::skipInitialResync() {
 }
 
 void Uc8279Driver::deepSleep(EpdBus& bus) {
-  if (_isScreenOn) {
-    bus.cmd(CMD_POWER_OFF);
-    bus.waitBusy(" 8279 power-down");
-    _isScreenOn = false;
-  }
+  // Always park before DSLP (see Uc8179Driver::deepSleep).
+  bus.cmd(CMD_POWER_OFF);
+  bus.waitBusy(" 8279 power-down");
+  _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);
 }

--- a/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
@@ -221,9 +221,11 @@ void Uc8279Driver::skipInitialResync() {
 }
 
 void Uc8279Driver::deepSleep(EpdBus& bus) {
-  // Always park before DSLP (see Uc8179Driver::deepSleep).
+  // Always park before DSLP (see Uc8179Driver::deepSleep for the full
+  // rationale). This driver is X3TwoPhase (Uc8279Driver.h) which DOES have a
+  // bounded busy wait, but only wait when the panel was actually on.
   bus.cmd(CMD_POWER_OFF);
-  bus.waitBusy(" 8279 power-down");
+  if (_isScreenOn) bus.waitBusy(" 8279 power-down");
   _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);

--- a/libs/display/FreeInkDisplay/src/driver/Uc8279X4Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279X4Driver.cpp
@@ -396,11 +396,10 @@ void Uc8279X4Driver::requestResync(uint8_t settlePasses) {
 void Uc8279X4Driver::skipInitialResync() { _needFullClear = false; }
 
 void Uc8279X4Driver::deepSleep(EpdBus& bus) {
-  if (_isScreenOn) {
-    bus.cmd(CMD_POWER_OFF);
-    bus.waitBusy(" 8279x4 power-down");
-    _isScreenOn = false;
-  }
+  // Always park before DSLP (see Uc8179Driver::deepSleep).
+  bus.cmd(CMD_POWER_OFF);
+  bus.waitBusy(" 8279x4 power-down");
+  _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);
 }

--- a/libs/display/FreeInkDisplay/src/driver/Uc8279X4Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279X4Driver.cpp
@@ -396,9 +396,11 @@ void Uc8279X4Driver::requestResync(uint8_t settlePasses) {
 void Uc8279X4Driver::skipInitialResync() { _needFullClear = false; }
 
 void Uc8279X4Driver::deepSleep(EpdBus& bus) {
-  // Always park before DSLP (see Uc8179Driver::deepSleep).
+  // Always park before DSLP (see Uc8179Driver::deepSleep for the full
+  // rationale). This driver is also UcIdleHigh (Uc8279X4Driver.h) with a
+  // no-timeout waitBusy(), so only wait when the panel was actually on.
   bus.cmd(CMD_POWER_OFF);
-  bus.waitBusy(" 8279x4 power-down");
+  if (_isScreenOn) bus.waitBusy(" 8279x4 power-down");
   _isScreenOn = false;
   bus.cmd(CMD_DEEP_SLEEP);
   bus.data(0xA5);

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -41,11 +41,15 @@ class FrontlightManager {
   // before deep sleep. Only meaningful on LEDC frontlights (no-op otherwise).
   // releaseOnWake() must be called at boot before begin() re-attaches the
   // channels.
+  // Implemented only under FREEINK_FRONTLIGHT_LS, so guard the declarations to
+  // match (otherwise boards without it get an undefined reference at link time).
+#ifdef FREEINK_FRONTLIGHT_LS
   void park();
 
   // Undo park() at boot so begin() can re-attach the LEDC channels. Safe to call
   // unconditionally; a no-op when not parked.
   void releaseOnWake();
+#endif
 
   // Warm/cool mix, 0 = fully cool, 100 = fully warm, 50 = neutral. Only meaningful on a
   // two-channel board (hasColorTemperature()); a no-op on single-channel frontlights.

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -46,8 +46,13 @@ class FrontlightManager {
 #ifdef FREEINK_FRONTLIGHT_LS
   void park();
 
-  // Undo park() at boot so begin() can re-attach the LEDC channels. Safe to call
-  // unconditionally; a no-op when not parked.
+  // Undo park() at boot so begin() can re-attach the LEDC channels. The release is
+  // UNCONDITIONAL: park() latches a digital pad hold that survives deep sleep AND
+  // the wake reset, while _lsParked (a DRAM flag) is lost on reset — so after a
+  // wake the hold is still present even though _lsParked reads false. Releasing
+  // unconditionally (gpio_hold_dis on a non-held pad is a harmless no-op) is the
+  // only way to guarantee the held pad is cleared; every other driver releases
+  // holds unconditionally before driving for this reason.
   void releaseOnWake();
 #endif
 

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -35,6 +35,18 @@ class FrontlightManager {
   void off();
   void on();
 
+  // Cut frontlight leakage through deep sleep: drive the LED pads LOW and hold
+  // them (so the level survives deep sleep via gpio_deep_sleep_hold_en), and
+  // release the LEDC KEEP_ALIVE clock. Call from the consumer's sleep path just
+  // before deep sleep. Only meaningful on LEDC frontlights (no-op otherwise).
+  // releaseOnWake() must be called at boot before begin() re-attaches the
+  // channels.
+  void park();
+
+  // Undo park() at boot so begin() can re-attach the LEDC channels. Safe to call
+  // unconditionally; a no-op when not parked.
+  void releaseOnWake();
+
   // Warm/cool mix, 0 = fully cool, 100 = fully warm, 50 = neutral. Only meaningful on a
   // two-channel board (hasColorTemperature()); a no-op on single-channel frontlights.
   void setColorTemperature(uint8_t warmPercent);
@@ -97,6 +109,7 @@ class FrontlightManager {
   void updateLsKeepAlive(bool lit);
   bool _lsAttachOk = false;         // both channel attaches succeeded (refcount is balanced)
   bool _lsKeepAliveArmed = false;   // our own +1 on the RC_FAST sleep sub-mode is active
+  bool _lsParked = false;           // park() has driven + held the frontlight pads LOW
 #endif
 
   bool _begun = false;

--- a/libs/hardware/FrontlightManager/include/FrontlightManager.h
+++ b/libs/hardware/FrontlightManager/include/FrontlightManager.h
@@ -107,9 +107,9 @@ class FrontlightManager {
   // re-arms it on 0<->nonzero total-duty transitions, so dark idle sleeps at
   // full depth.
   void updateLsKeepAlive(bool lit);
-  bool _lsAttachOk = false;         // both channel attaches succeeded (refcount is balanced)
-  bool _lsKeepAliveArmed = false;   // our own +1 on the RC_FAST sleep sub-mode is active
-  bool _lsParked = false;           // park() has driven + held the frontlight pads LOW
+  bool _lsAttachOk = false;        // both channel attaches succeeded (refcount is balanced)
+  bool _lsKeepAliveArmed = false;  // our own +1 on the RC_FAST sleep sub-mode is active
+  bool _lsParked = false;          // park() has driven + held the frontlight pads LOW
 #endif
 
   bool _begun = false;

--- a/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
+++ b/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
@@ -327,6 +327,57 @@ void FrontlightManager::updateLsKeepAlive(const bool lit) {
   esp_sleep_sub_mode_config(ESP_SLEEP_DIG_USE_RC_FAST_MODE, lit);
   _lsKeepAliveArmed = lit;
 }
+
+void FrontlightManager::park() {
+  // Frontlight leakage through deep sleep (Xteink X4 Pro — Mark31415,
+  // crosspoint-reader#3215). The channels are configured LEDC_SLEEP_MODE_KEEP_ALIVE
+  // so the PWM keeps driving GPIO8/9 (cool/warm) through light sleep; at deep
+  // sleep the panel rail is held up (PR #3215 holds power.latch0 / GPIO1 HIGH for
+  // fast-wake), so the frontlight driver IC stays powered and the KEEP_ALIVE pad
+  // keeps drawing quiescent + leakage current. Cut it at the source: drive both
+  // pads LOW (active-high frontlight -> LED off, no booster bias) and hold them
+  // LOW so the level survives deep sleep via gpio_deep_sleep_hold_en() (called by
+  // PowerManager::deepSleep()). The LEDC peripheral clock (RC_FAST) is also
+  // released so the driver's refcounted +1 is dropped and the clock can fully
+  // stop in deep sleep. releaseOnWake() must undo this before begin() re-attaches
+  // the LEDC channels on boot.
+  const auto& fl = BoardConfig::ACTIVE.frontlight;
+  if (!_begun) return;
+  // Return the LEDC driver's refcounted RC_FAST keep-alive it took at attach, if
+  // it is still armed (apply() re-arms only while lit; off()/setBrightness(0)
+  // returns it, but be safe if the light was parked while lit).
+  updateLsKeepAlive(false);
+  // Tear down the KEEP_ALIVE LEDC channels so the pads no longer answer to the
+  // peripheral; the explicit GPIO hold below then owns the pad level.
+  ledc_stop(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, 0);
+  if (fl.gpioWarm != BoardConfig::PIN_UNASSIGNED) {
+    ledc_stop(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_1, 0);
+  }
+  for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
+    if (pin < 0) continue;
+    const auto g = static_cast<gpio_num_t>(pin);
+    // Release any surviving pad hold first: a held pad silently ignores the drive
+    // below (same trap as HalPowerManager's latch loop).
+    gpio_hold_dis(g);
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, LOW);
+    gpio_hold_en(g);
+    _lsParked = true;
+  }
+}
+
+void FrontlightManager::releaseOnWake() {
+  // Undo park() so begin() can re-attach the LEDC channels cleanly: drop the pad
+  // holds (a held pad would make ledc_channel_config()'s drive a no-op) and clear
+  // the parked flag. Called from the consumer at boot, before Frontlight.begin().
+  if (!_lsParked) return;
+  const auto& fl = BoardConfig::ACTIVE.frontlight;
+  for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
+    if (pin < 0) continue;
+    gpio_hold_dis(static_cast<gpio_num_t>(pin));
+  }
+  _lsParked = false;
+}
 #endif
 #endif
 

--- a/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
+++ b/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
@@ -1,11 +1,14 @@
 #include "FrontlightManager.h"
 
 #if FREEINK_CAP_FRONTLIGHT
+static const char* TAG = "FrontlightMgr";
+
 #include <M5Pm1.h>
 #include <Wire.h>
 #ifdef FREEINK_FRONTLIGHT_LS
 #include <driver/gpio.h>
 #include <driver/ledc.h>
+#include <esp_log.h>
 // esp_sleep_sub_mode_config lives in a private IDF header (no public API exists
 // for balancing the refcounted RC_FAST keep-on the LEDC driver takes for
 // KEEP_ALIVE channels — the driver manages it through this same header). Pinned
@@ -167,6 +170,17 @@ void FrontlightManager::begin() {
     attachOk = attachChannel(fl.gpioWarm, LEDC_CH_WARM, fl.pwmFrequency, fl.pwmResolutionBits) || attachOk;
   }
 #ifdef FREEINK_FRONTLIGHT_LS
+  // Defensive: a prior sleep cycle may have left _lsParked set if releaseOnWake()
+  // was skipped (bad ordering, mid-flash). If the pad is still held, the LEDC
+  // re-attach below would be a no-op and the light would stay dark after wake.
+  // Drop any surviving hold here so begin() always starts from a clean pad.
+  if (_lsParked) {
+    for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
+      if (pin >= 0) gpio_hold_dis(static_cast<gpio_num_t>(pin));
+    }
+    _lsParked = false;
+    ESP_LOGI(TAG, "begin: cleared stale parked hold (was parked)");
+  }
   // The FIRST successful KEEP_ALIVE channel config takes a single refcounted +1
   // on the RC_FAST sleep sub-mode (esp_sleep_sub_mode_config; the driver's
   // global-clock latch means later configs don't take another), which would
@@ -186,6 +200,7 @@ void FrontlightManager::begin() {
 #endif
   _begun = true;
   setBrightness(0);
+  ESP_LOGI(TAG, "begin: attached gpio=%d warm=%d ok=%d", fl.gpio, fl.gpioWarm, attachOk ? 1 : 0);
 #endif
 }
 
@@ -316,6 +331,8 @@ void FrontlightManager::apply() {
   if (dual) {
     writeChannel(fl.gpioWarm, LEDC_CH_WARM, physicalDuty(warmDuty, full, fl.activeHigh));
   }
+  ESP_LOGI(TAG, "apply: brightness=%u level=%u totalDuty=%u coolDuty=%u warmDuty=%u lit=%d", _brightness,
+           _brightnessLevel, totalDuty, coolDuty, warmDuty, totalDuty != 0 ? 1 : 0);
 }
 
 #ifdef FREEINK_FRONTLIGHT_LS
@@ -343,6 +360,7 @@ void FrontlightManager::park() {
   // the LEDC channels on boot.
   const auto& fl = BoardConfig::ACTIVE.frontlight;
   if (!_begun) return;
+  ESP_LOGI(TAG, "park: begun, driving pads LOW + hold");
   // Return the LEDC driver's refcounted RC_FAST keep-alive it took at attach, if
   // it is still armed (apply() re-arms only while lit; off()/setBrightness(0)
   // returns it, but be safe if the light was parked while lit).
@@ -370,13 +388,20 @@ void FrontlightManager::releaseOnWake() {
   // Undo park() so begin() can re-attach the LEDC channels cleanly: drop the pad
   // holds (a held pad would make ledc_channel_config()'s drive a no-op) and clear
   // the parked flag. Called from the consumer at boot, before Frontlight.begin().
-  if (!_lsParked) return;
+  // Idempotent: safe to call more than once (e.g. begin() ALSO clears a stale hold
+  // defensively), and a no-op when never parked — so the wake path can call it
+  // unconditionally without risk of being a silent no-op that leaves the pad held.
+  if (!_lsParked) {
+    ESP_LOGI(TAG, "releaseOnWake: not parked (no-op)");
+    return;
+  }
   const auto& fl = BoardConfig::ACTIVE.frontlight;
   for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
     if (pin < 0) continue;
     gpio_hold_dis(static_cast<gpio_num_t>(pin));
   }
   _lsParked = false;
+  ESP_LOGI(TAG, "releaseOnWake: released pad holds");
 }
 #endif
 #endif

--- a/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
+++ b/libs/hardware/FrontlightManager/src/FrontlightManager.cpp
@@ -1,20 +1,26 @@
 #include "FrontlightManager.h"
 
 #if FREEINK_CAP_FRONTLIGHT
-static const char* TAG = "FrontlightMgr";
+#include "FrontlightManager.h"
 
 #include <M5Pm1.h>
 #include <Wire.h>
 #ifdef FREEINK_FRONTLIGHT_LS
 #include <driver/gpio.h>
 #include <driver/ledc.h>
-#include <esp_log.h>
 // esp_sleep_sub_mode_config lives in a private IDF header (no public API exists
 // for balancing the refcounted RC_FAST keep-on the LEDC driver takes for
 // KEEP_ALIVE channels — the driver manages it through this same header). Pinned
 // IDF 5.5; re-check on IDF bumps.
 #include <esp_private/esp_sleep_internal.h>
 #endif
+
+// Logging: use the firmware's Logging.h LOG_INF facility, NOT esp_log. The
+// prebuilt Arduino sdkconfig sets CONFIG_LOG_DEFAULT_LEVEL_ERROR, so ESP_LOGI is
+// compiled out, and esp_log writes to the IDF UART console rather than the
+// firmware's Serial stream the monitor reads. LOG_INF routes through logPrintf
+// to the firmware Serial and the crash-report ring buffer.
+#include <Logging.h>
 
 namespace {
 constexpr uint32_t maxDuty(uint8_t bits) { return (1u << bits) - 1u; }
@@ -170,17 +176,17 @@ void FrontlightManager::begin() {
     attachOk = attachChannel(fl.gpioWarm, LEDC_CH_WARM, fl.pwmFrequency, fl.pwmResolutionBits) || attachOk;
   }
 #ifdef FREEINK_FRONTLIGHT_LS
-  // Defensive: a prior sleep cycle may have left _lsParked set if releaseOnWake()
-  // was skipped (bad ordering, mid-flash). If the pad is still held, the LEDC
-  // re-attach below would be a no-op and the light would stay dark after wake.
-  // Drop any surviving hold here so begin() always starts from a clean pad.
-  if (_lsParked) {
-    for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
-      if (pin >= 0) gpio_hold_dis(static_cast<gpio_num_t>(pin));
-    }
-    _lsParked = false;
-    ESP_LOGI(TAG, "begin: cleared stale parked hold (was parked)");
+  // Defensive: a prior sleep cycle may have left the pads held (park() latches a
+  // digital hold that survives deep sleep AND the wake reset while the _lsParked
+  // DRAM flag is lost). Release any surviving hold here so begin() always starts
+  // from a clean pad — a held pad silently ignores the LEDC drive below. The
+  // release is unconditional (gpio_hold_dis on a non-held pad is a harmless no-op)
+  // because we cannot trust _lsParked after a reset.
+  for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
+    if (pin >= 0) gpio_hold_dis(static_cast<gpio_num_t>(pin));
   }
+  _lsParked = false;
+  LOG_INF("FrontlightMgr", "begin: cleared any stale held pads");
   // The FIRST successful KEEP_ALIVE channel config takes a single refcounted +1
   // on the RC_FAST sleep sub-mode (esp_sleep_sub_mode_config; the driver's
   // global-clock latch means later configs don't take another), which would
@@ -200,7 +206,7 @@ void FrontlightManager::begin() {
 #endif
   _begun = true;
   setBrightness(0);
-  ESP_LOGI(TAG, "begin: attached gpio=%d warm=%d ok=%d", fl.gpio, fl.gpioWarm, attachOk ? 1 : 0);
+  LOG_INF("FrontlightMgr", "begin: attached gpio=%d warm=%d ok=%d", fl.gpio, fl.gpioWarm, attachOk ? 1 : 0);
 #endif
 }
 
@@ -331,7 +337,7 @@ void FrontlightManager::apply() {
   if (dual) {
     writeChannel(fl.gpioWarm, LEDC_CH_WARM, physicalDuty(warmDuty, full, fl.activeHigh));
   }
-  ESP_LOGI(TAG, "apply: brightness=%u level=%u totalDuty=%u coolDuty=%u warmDuty=%u lit=%d", _brightness,
+  LOG_INF("FrontlightMgr", "apply: brightness=%u level=%u totalDuty=%u coolDuty=%u warmDuty=%u lit=%d", _brightness,
            _brightnessLevel, totalDuty, coolDuty, warmDuty, totalDuty != 0 ? 1 : 0);
 }
 
@@ -360,7 +366,7 @@ void FrontlightManager::park() {
   // the LEDC channels on boot.
   const auto& fl = BoardConfig::ACTIVE.frontlight;
   if (!_begun) return;
-  ESP_LOGI(TAG, "park: begun, driving pads LOW + hold");
+  LOG_INF("FrontlightMgr", "park: begun, driving pads LOW + hold");
   // Return the LEDC driver's refcounted RC_FAST keep-alive it took at attach, if
   // it is still armed (apply() re-arms only while lit; off()/setBrightness(0)
   // returns it, but be safe if the light was parked while lit).
@@ -388,20 +394,22 @@ void FrontlightManager::releaseOnWake() {
   // Undo park() so begin() can re-attach the LEDC channels cleanly: drop the pad
   // holds (a held pad would make ledc_channel_config()'s drive a no-op) and clear
   // the parked flag. Called from the consumer at boot, before Frontlight.begin().
-  // Idempotent: safe to call more than once (e.g. begin() ALSO clears a stale hold
-  // defensively), and a no-op when never parked — so the wake path can call it
-  // unconditionally without risk of being a silent no-op that leaves the pad held.
-  if (!_lsParked) {
-    ESP_LOGI(TAG, "releaseOnWake: not parked (no-op)");
-    return;
-  }
+  //
+  // CRITICAL: the release must be UNCONDITIONAL. park() latches a digital pad hold
+  // (gpio_hold_en) that survives deep sleep AND the wake reset, but _lsParked is a
+  // plain DRAM flag that is lost on the same reset. After a wake, _lsParked is
+  // always false even though the pad is still held — gating the release on it would
+  // leave the pad held forever (light dark until power-cycle). gpio_hold_dis on a
+  // non-held pad is a harmless no-op, so releasing unconditionally is safe and
+  // idempotent. Every other driver in this codebase releases holds unconditionally
+  // before driving for exactly this reason.
   const auto& fl = BoardConfig::ACTIVE.frontlight;
   for (const int8_t pin : {fl.gpio, fl.gpioWarm}) {
     if (pin < 0) continue;
     gpio_hold_dis(static_cast<gpio_num_t>(pin));
   }
   _lsParked = false;
-  ESP_LOGI(TAG, "releaseOnWake: released pad holds");
+  LOG_INF("FrontlightMgr", "releaseOnWake: cleared pad holds (unconditional)");
 }
 #endif
 #endif


### PR DESCRIPTION
PR crosspoint-reader/crosspoint-reader#3215 holds the X4 Pro master peripheral rail (power.latch0 = GPIO1) HIGH through deep sleep so battery-only sleep fast-wakes instead of cold-booting. Correct, but it exposed a latent driver bug: if the panel is not actually parked, the held rail keeps the panel's VCC up while the charge-pump/booster stays biased -> mA drain (the pre-PR state masked it because the latch floated LOW and the rail dropped).

The X4 Pro panel driver is boot-probed and may be promoted to SSD1677, UC8179 or UC8279X4 (XteinkDetect.cpp:334-353). Every driver gates the panel power-off on _isScreenOn while issuing DSLP unconditionally. Ssd1677Driver also desyncs the flag: after an AA/grayscale pass with turnOff==false the rails stay up (0xCC = CLOCK_ON|ANALOG_ON) but _isScreenOn is forced false (Ssd1677Driver.cpp:358), so powerOffController() early-returns (line 383) and DSLP is issued with the booster biased.

Make 'deepSleep() always parks the panel' an idempotent invariant:
- Ssd1677Driver: only clear _isScreenOn when turnOff actually powered down; drop the guard in powerOffController() so the booster-off always runs.
- Uc8179/Uc8279X4/Uc8279: drop the if(_isScreenOn) gate; always emit POF before DSLP (re-issuing POF on an already-off panel is harmless).

Builds clean for -e x4pro; pairs with crosspoint-reader#3215.

CF: https://github.com/crosspoint-reader/crosspoint-reader/commit/f0c655062c5135753134443d56513f8202208f6a#commitcomment-198022530

@itsthisjustin testing this on my side, don't hesitate to also test it.

Basically, we want to be sure the screen is off when we go to deepSleep