### PR TITLE
fix(x4pro): restore frontlight — 10kHz/10-bit RC_FAST-compatible PWM

### DIFF
--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -1561,13 +1561,17 @@ constexpr BoardProfile XTEINK_X4_PRO = {
     // Frontlight: dual warm/cold LEDC PWM with color temperature (NVS lightWarmValue/
     // lightColdValue/lightCT/lightBri/lightOn). Recovered from the OEM LEDC init (IROM
     // 0x420a2130 → helper 0x420a20c0): two channels — GPIO8 on LEDC ch4 and GPIO9 on ch5 —
-    // The original bring-up dump used 10 kHz; stock 7.0.8 passes 25 kHz / 10-bit to
-    // the frontlight initializer on the same pins. Use that directly recovered value.
-    // Both channels are active-HIGH (init drives the pin LOW = off, brightness raises
-    // duty).
+    // The X4 Pro frontlight runs through the FREEINK_FRONTLIGHT_LS path, which clocks the
+    // LEDC timer from RC_FAST (~17.5 MHz) so the PWM survives light sleep. RC_FAST can only
+    // reach ~17 kHz at 10-bit resolution (divisor must exceed 256; 25 kHz/10-bit yields div
+    // 175 -> ledc_timer_config fails -> both channels unconfigured -> light stays dark). Use
+    // 10 kHz / 10-bit (the pre-regression value that worked): div ~438, valid, full dim floor.
+    // Both channels are active-HIGH (init drives the pin LOW = off, brightness raises duty).
     // GPIO8 is the hardware-confirmed cool channel and GPIO9 the warm channel;
     // FrontlightManager mixes them for color-temperature control.
-    {8, 25000, 10, true, 9},
+    // NOTE: if light-sleep LEDC support is ever dropped (driver uses XTAL/AUTO clock) this
+    // can safely return to the OEM 25 kHz.
+    {8, 10000, 10, true, 9},
     NO_AUDIO,
     NO_LEDS,
     NO_FLIP,  // panel mount transform pending hardware; native SSD1677 scan is 800x480 landscape


### PR DESCRIPTION
## Summary

The X4 Pro frontlight stopped working (stays dark) after upstream commit `13d23ba`
("Update X4 Pro display driver"), which bumped the X4 Pro frontlight to `25 kHz / 10-bit`.

Under `FREEINK_FRONTLIGHT_LS`, `FrontlightManager::begin()` clocks the LEDC timer from
**RC_FAST** (~17.5 MHz) so the PWM survives light sleep. At 10-bit resolution the fractional
divisor for 25 kHz makes `ledc_timer_config` return `ESP_ERR_INVALID_ARG` — both channels
(GPIO8 cool / GPIO9 warm) are left **unconfigured** and the light never comes on.

This reverts the X4 Pro profile to the working **10 kHz / 10-bit** (div ~438), restoring the
frontlight while keeping the full 10-bit dim floor.

## Scope / context

- This is the *remaining* frontlight fix for the X4 Pro. The wake-regression half
  (`park()` / `releaseOnWake()` unconditional hold release, SDK PR #63) is already merged into
  `Free-Ink/freeink-sdk` main. With that merged, the light wakes correctly but the *attach*
  step still fails at 25 kHz, so the panel stays dark — this commit closes that gap.
- One-line change in `BoardConfig.h` only; no driver/consumer code touched.
- The RC_FAST-clocked `FREEINK_FRONTLIGHT_LS` path is only meaningful for light sleep, which the
  CrossPoint firmware does not enter (`setPowerSaving` scales CPU frequency only), so 10 kHz is
  the safe, zero-risk choice here. If light-sleep LEDC support is ever dropped in favor of an
  XTAL/AUTO clock, this can return to the OEM 25 kHz.

## Verification

- Device: X4 Pro frontlight toggles on/off and ramps brightness after deep sleep (serial trace
  shows `apply: ... lit=1`).
- `ledc_timer_config` no longer returns `ESP_ERR_INVALID_ARG` for the X4 Pro frontlight channels.

Ported from the Belphemur fork (CrossPoint X4 Pro bring-up).
