### PR TITLE
fix(ui): thread dithered foreground through textStyleWithForeground

### DIFF
--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -889,6 +889,14 @@ TextStyle textStyleWithForeground(TextStyle text, Paint foreground) {
   if (foreground.kind == PaintKind::Solid) {
     text.color = foreground.color;
     text.inverted = foreground.color == Color::White;
+  } else if (foreground.kind == PaintKind::Dither) {
+    // A dithered foreground (e.g. a disabled list row's dither(LightGray))
+    // must reach the renderer's dithered text path. Without this, the color
+    // stays at its default Black and the rasterizer takes the solid-black
+    // path, so a disabled row renders indistinguishable from an enabled one
+    // even though its resolved style carried a gray foreground.
+    text.color = foreground.color;
+    text.inverted = false;
   }
   return text;
 }


### PR DESCRIPTION
## Summary
A disabled `ListItem` (or any control whose resolved style carries a dithered foreground) rendered pixel-identical to an enabled one — its disabled state was invisible.

## Root cause
`textStyleWithForeground()` (libs/ui/FreeInkUI/src/FreeInkUI.cpp) only copied the color when `foreground.kind == PaintKind::Solid`. A disabled list row resolves to `dither(Color::LightGray)` (a `Dither` paint), so `TextStyle.color` stayed at its default `Black`. Downstream, the renderer's `text()` computed `dithered = false` and took the solid-black path — the gray foreground never reached the dithered text rasterizer.

## Fix
Handle `PaintKind::Dither` in `textStyleWithForeground()` by copying the color (and not forcing `inverted`), so the renderer's dithered text path renders the gray label. The disabled row **background is intentionally left as `solid(White)`** — only the label text dims to gray. This complements the existing `drawTextDither` rasterizer plumbing, which previously received no gray color to draw.

## Scope
- Single-file change in `libs/ui/FreeInkUI/src/FreeInkUI.cpp` (no API/struct changes, no other callers affected).
- No `clang-format` in this repo; edit hand-styled to match the surrounding ~100-col hand style.

## Verification
- FreeInkUI host harness (`libs/ui/FreeInkUI/test/host/test_freeinkui.cpp`): **2796 checks, 0 failed**.

## AI Usage
YES — agent-assisted.