### PR TITLE
fix(display): prevent EpdBus reset from power-cycling shared SD rail on OnePage

### DIFF
--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
@@ -1,5 +1,6 @@
 #include "EpdBus.h"
 
+#include <BoardConfig.h>
 #include <driver/gpio.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
@@ -109,6 +110,17 @@ void EpdBus::begin(const EpdPins& pins, uint32_t spiHz, BusyPolarity busy, int8_
 }
 
 void EpdBus::reset(uint16_t extraSettleMs) {
+  if (BoardConfig::isOnePage()) {
+    // OnePage shares GPIO27 between EPD reset and the SD/MIC power rail.
+    // Pulsing it low after Storage.begin() cuts power to the mounted SD card,
+    // causing subsequent SD reads to fail. Keep the rail powered; SSD1677
+    // performs CMD_SOFT_RESET immediately after.
+    if (_pins.rst >= 0) {
+      digitalWrite(_pins.rst, HIGH);
+    }
+    return;
+  }
+
   const auto setReset = [this](bool high) {
     if (_pins.rst >= 0) {
       digitalWrite(_pins.rst, high ? HIGH : LOW);


### PR DESCRIPTION
### Summary                                                                                                                  
On the OnePage board, `GPIO 27` is multiplexed: it serves as both the e-paper hardware reset (`EPD RST`) and the shared `SD/MIC` peripheral power rail (`sd.powerEnable`).                                                                             
                                                                                                                                 
During startup in applications like `crosspoint-reader`:                                                                     
    1. `Storage.begin()` runs first, driving GPIO 27 HIGH and mounting the SD card.                                              
    2. Subsequently, `display.begin()` calls `EpdBus::reset()`, which unconditionally pulsed RST (GPIO 27) LOW for 10 ms.        
    3. This 10 ms drop momentarily cuts power to the already-mounted SD card (brownout), causing subsequent directory and file   
  reads to fail silently with 0 files found.                                                                                     
                                                                                                                                 
### Fix                                                                                                                      
- In `EpdBus::reset()`, check `BoardConfig::isOnePage()`. If running on OnePage, keep GPIO 27 driven HIGH rather than pulsing
  it LOW.                                                                                                                        
- The SSD1677 e-paper controller executes `CMD_SOFT_RESET (0x12)` immediately afterwards during controller initialization, sothe display is fully and cleanly reset without disrupting the SD card power.                                                   
                                                                                                                                 
### Testing                                                                                                                  
- Tested and verified on physical OnePage ESP32-C61 hardware with `crosspoint-reader`.                                       
- SD card files and directories are now reliably recognized and browsable.  