### PR TITLE
fix(t5s3): stop the EPD config asserting the LoRa radio chip select

### DIFF
--- a/libs/hardware/BoardT5S3/src/LilyGoT5S3LgfxConfig.cpp
+++ b/libs/hardware/BoardT5S3/src/LilyGoT5S3LgfxConfig.cpp
@@ -84,6 +84,28 @@ bool waitForTpsReady(uint32_t timeoutMs) {
 }
 
 bool prepareEpdPower() {
+  // Deselect the SX1262 before the EPD bus is built, and do it here rather than
+  // anywhere else, because this hook is the last thing that runs before
+  // Bus_EPD::init() (LgfxEpdDriver.cpp, FreeInkBusEPD::init()).
+  //
+  // pinPwr below is T5S3_LORA_CS (GPIO46) and has to stay a real GPIO: it is
+  // handed to the i80 driver as dc_gpio_num, and the IDF rejects a negative one
+  // (esp_lcd_panel_io_i80.c, lcd_i80_bus_configure_gpio). GPIO46 is also the
+  // LoRa radio's NSS, on the same SPI bus as the SD card. Bus_EPD::init() then
+  // makes it an output with lgfx::pinMode(), which does NOT write a level
+  // (common.cpp, the gpio_hi() there is guarded to non-output modes), so the pin
+  // keeps whatever the output register held -- 0 out of reset. That asserts the
+  // radio's chip select for the whole run, and measured on hardware 2026-09-03
+  // the SD card is unreadable whenever the radio is selected while its supply
+  // rail is off.
+  //
+  // Writing the level here survives, for the same reason the bug exists: nothing
+  // downstream sets it. Between the i80 bus setup and the pinMode that hands the
+  // pad back to plain GPIO out, the peripheral drives DC on it for a few
+  // microseconds, and that is the one window this does not cover.
+  pinMode(T5S3_LORA_CS, OUTPUT);
+  digitalWrite(T5S3_LORA_CS, HIGH);
+
   pinMode(EP_STV, OUTPUT);
   digitalWrite(EP_STV, LOW);
 
@@ -159,10 +181,20 @@ const LgfxEpdConfig& lilygoT5S3LgfxConfig() {
       {EP_D0, EP_D1, EP_D2, EP_D3, EP_D4, EP_D5, EP_D6, EP_D7},
       EP_STH,
       EP_STV,
-      T5S3_LORA_CS,
+      // pinOe: -1, not a dummy pin. This panel's real output-enable is
+      // PCA9535_IO10_EP_OE, driven by the hooks above, so LovyanGFX needs no OE
+      // of its own. It used to carry T5S3_LORA_CS as a placeholder, which put
+      // the LoRa radio's chip select on an EPD pin. lgfx tolerates -1: pinMode()
+      // returns early for a pin past GPIO_NUM_MAX and gpio_hi/gpio_lo are
+      // guarded on pin >= 0.
+      -1,
       EP_LEH,
       EP_CKH,
       EP_CKV,
+      // pinPwr: still T5S3_LORA_CS and it has to be, because this one reaches
+      // the i80 driver as dc_gpio_num and a negative value is rejected. There is
+      // no free GPIO on this board to give it instead. prepareEpdPower() above
+      // deselects it before the bus is built, which is what makes it harmless.
       T5S3_LORA_CS,
       16000000,
       8,


### PR DESCRIPTION
## Summary

**Goal.** On the LilyGo T5 S3 Pro, `lilygoT5S3LgfxConfig()` passes `T5S3_LORA_CS`
(GPIO46) as both `pinOe` and `pinPwr`. That pin is the SX1262's `NSS`, and it sits
on the same SPI bus as the SD card. `Bus_EPD::init()` leaves it driven low, which
asserts the radio's chip select for the whole run, and the SD card then fails.

**Changes.**

* `pinOe` becomes `-1`. This panel has no LovyanGFX-side output-enable: the real
  one is `PCA9535_IO10_EP_OE`, driven by the injected hooks.
* `pinPwr` stays `T5S3_LORA_CS`, because it reaches the i80 driver as
  `dc_gpio_num` and the IDF rejects a negative value
  (`esp_lcd_panel_io_i80.c`, `lcd_i80_bus_configure_gpio`). There is no free GPIO
  on this board to offer instead.
* `prepareEpdPower()` deselects GPIO46 before the bus is built. That hook is the
  last thing to run before `Bus_EPD::init()`, and nothing downstream writes the
  level back.

One file, 33 lines added, one line changed.

## The symptom

Everything that touched the card failed, from unrelated tasks and in each task's
own vocabulary: BLE tile transfers answered `ERR mkdir failed`, `settings.json`
would not save, the Wi-Fi file server answered HTTP 500 to `/mkdir` and listed
the volume as empty, and roughly one boot in two came up on the firmware's
"SD card error" screen. The card itself was fine: it read and wrote correctly in
a USB reader, and two different cards behaved identically in the board.

## Why the pin ends up asserted

Both fields were placeholders from the start, and the commit that added the
driver says so: `9becf6c` writes `/*OE dummy*/ T5S3_LORA_CS` and
`/*pwr dummy*/ T5S3_LORA_CS`, and `LgfxEpdConfig.h` documents `pinOe` as "may be
a dummy GPIO if real OE is via an expander hook". The two fields are mandatory,
this panel needs neither, and GPIO46 was what was to hand.

`Bus_EPD::init()` then calls `lgfx::pinMode(pin, output)` on both. That call
does not write a level: its `gpio_hi()` is guarded to non-output modes. So the
pad becomes an output holding whatever the output register had, which is 0 out of
reset, and nothing raises it again. The `powerControl()` that would have set a
level is overridden by `FreeInkBusEPD` without calling the base, so it never
runs.

## What was measured, and on what

Measured 2026-09-03 on a T5 S3 Pro, with a bench command that toggles the
radio's chip select, its reset line and the shared GNSS/LoRa supply rail
independently and reads a 19,855-byte file off the card with a CRC32. Nine runs,
each after a hard reset with a passing baseline read first.

* **With the radio deselected, the card read correctly in every combination
  tried** -- rail on or off, reset driven or floating. This is the result the
  change rests on.
* With the radio selected, the read failed unless the radio was **both** powered
  **and** had its reset line actively driven. Five failures, three passes, no
  exceptions in either direction.
* The failure is sticky within a boot: raising the chip select again does not
  restore the card.

The change was verified on hardware against our pinned base (`e514a868`), not
against `main`: a build carrying only this SDK change, with the workaround we had
in our own firmware removed, boots with the pin high, reads the card, and keeps
reading it with the shared rail cut -- which was previously the dead state.
Manually asserting the chip select still breaks it, so the failure mode has not
gone away, only stopped being triggered. The patch cherry-picks onto `main`
cleanly but has not been run from `main`.

**Not claimed.** GPIO46 has not been probed on the pad, so "the radio is
selected" is read off the code rather than measured. Why an SX1262 in an
undefined state loads the shared MISO is our inference; we have no SX126x
datasheet to cite for it. And this is not a board fault: the T5 S3 Pro is wired
the ordinary way for a device with both a radio and a card, and it is our EPD
configuration that drives the radio's chip select.

## Why nobody hit it sooner

On our board it was masked for two days by unrelated work. Our GNSS bring-up
powers the shared rail and drives the radio's reset low, which is exactly the
combination the card tolerates. When a test run turned the GNSS setting off, the
masking went with it and the card died. Any board configured this way and not
running GNSS would meet it immediately.

## Related

`#72` (`fix/onepage-sd-power-rail`, merged into `main`) is the same class on a
different board: an EPD driver pulsing a pin that also gates the SD rail, with
the same collateral. This is the T5 S3 Pro instance of it.

## Additional context

* **Risk.** The change touches display init on one board. The two levels written
  in `prepareEpdPower()` are new; everything else is a config value.
* **Not covered.** Between `esp_lcd_new_i80_bus()` mapping DC onto the pad and
  the `pinMode()` that hands it back to plain GPIO out, the peripheral drives DC
  on GPIO46 for a few microseconds. That window remains, with or without this
  change. Removing it would mean not giving `dc_gpio_num` a pin the board uses
  for something else, which this board cannot do.
* **Flash and RAM.** No measurable change: two `digitalWrite` calls and a
  constant. Our `env:t5s3pro` build stayed at 21.7 % RAM and 58.7 % flash.
* **Testing offered.** We have the board and can run anything a reviewer wants,
  including from `main`.

### AI usage

PARTIALLY. An AI coding assistant was used for the investigation and for
drafting this description. **The code work is the maintainer's own, and the
finding itself and every hardware test behind it were carried out by hand on the
board** -- the bench runs, the flashing, the card checks in a reader, all of it.

Every claim above is either a code citation a reviewer can check or a
measurement taken on that board. The paragraph on what is not claimed is there
because the first two versions of this diagnosis were wrong and were refuted
before this PR was written.
