### PR TITLE
fix(ui): dropdown icon style binds a reference to a destroyed temporary

### DIFF
--- a/libs/ui/FreeInkUI/include/components/lists/dropdown.h
+++ b/libs/ui/FreeInkUI/include/components/lists/dropdown.h
@@ -67,8 +67,7 @@ void dropdown(Frame<MaxInteractions>& frame, Rect rect, const DropdownProps& pro
     const int16_t iconSize = props.iconSize > 0 ? props.iconSize : static_cast<int16_t>(icon.width);
     Rect iconRect{content.x, static_cast<int16_t>(band.y + (band.height - iconSize) / 2),
                   iconSize, iconSize};
-    const BoxStyle& iconStyle = (props.styles.unset() ? defaultButtonStyles() : props.styles).resolve(state);
-    frame.target().bitmap(iconRect, icon, BitmapMode::Contain, iconStyle.foreground);
+    frame.target().bitmap(iconRect, icon, BitmapMode::Contain, style.foreground);
     const int16_t shift = static_cast<int16_t>(iconSize + props.gap);
     content.x = static_cast<int16_t>(content.x + shift);
     content.width = static_cast<int16_t>(content.width - shift);


### PR DESCRIPTION
## Summary

`dropdown()` binds a `const BoxStyle&` into a temporary that is destroyed at the end of the same statement, then reads through it on the next line. One line changed, one removed.

```cpp
// libs/ui/FreeInkUI/include/components/lists/dropdown.h:70
const BoxStyle& iconStyle = (props.styles.unset() ? defaultButtonStyles() : props.styles).resolve(state);
frame.target().bitmap(iconRect, icon, BitmapMode::Contain, iconStyle.foreground);   // reads freed storage
```

`defaultButtonStyles()` is declared `StyleSet defaultButtonStyles();` — **by value**. So the conditional yields a prvalue `StyleSet`, `resolve()` hands back a reference into it, and the temporary's lifetime ends at the semicolon. Reading `iconStyle.foreground` afterwards is undefined behaviour. It has gone unnoticed because the freed stack slot almost always still holds the right bytes.

## The fix

Use `style`, which is already in scope five lines above and is provably the same `BoxStyle`:

- `state` is assigned once (`state = frame.stateFor(...)`) before `style` is resolved, and is never touched again in the function — both resolutions see the same state.
- `styles` differs from the conditional only by `setStyleRadius()`, which writes `.radius` on each of the five `BoxStyle`s and nothing else.

So `.foreground` is identical either way, and the icon ends up taking its colour from the same `BoxStyle` the label and subtitle already take theirs from two lines earlier via `textStyleWithForeground(..., style.foreground)`. No behaviour change.

## Why it is worth fixing now rather than later

It already breaks the repo's own test suite on a current toolchain. `libs/ui/FreeInkUI/test/host/run.sh` compiles with `-Wall -Wextra -Werror`, and GCC 13+ diagnoses exactly this as `-Wdangling-reference`, so on GCC 15 the suite does not build at all:

```
dropdown.h:70:21: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
   70 |     const BoxStyle& iconStyle = (props.styles.unset() ? defaultButtonStyles() : props.styles).resolve(state);
      |                     ^~~~~~~~~
dropdown.h:70:55: note: 'const freeink::ui::StyleSet' temporary created here
```

Before: does not compile. After: **2804 checks, 0 failed**. That was the only `-Werror` failure in the suite — nothing else was hiding behind it.

## Scope check

I looked at every reference in FreeInkUI bound to a `.resolve()` result — table, popup, header, setting-row, option-dialog, checkbox, message-panel, book-card, cover-carousel, cover-grid, text-field, context-menu, metric-card, button, tab-bar. All of them resolve off a **named local** that outlives the reference. This was the only site that did not.

`stepper-row.h:58` and `keyboard.h:505` build the same `unset() ? defaultButtonStyles() : ...` conditional, but assign it to a `StyleSet` **by value**, so they are safe and are left alone.

## Testing

`libs/ui/FreeInkUI/test/host/run.sh` — 2804 checks, 0 failed, GCC 15.2, `-std=c++17 -Wall -Wextra -Werror`. No firmware build is affected: this is a header-only widget and the change is one expression.

Found while merging `main` into a downstream fork, where the suite stopped building; the failure reproduces on unmodified `main`.

### AI usage

PARTIALLY. An AI coding assistant was used to investigate the diagnostic, check the equivalence argument against the surrounding code, survey the other `.resolve()` call sites, and draft this description.
