### PR TITLE
fix(list): keep a nav list scrollable when measured rows are clipped

### DIFF
--- a/docs/freeink-ui.md
+++ b/docs/freeink-ui.md
@@ -977,6 +977,26 @@ freeink::ui::list(ui, rect, props);
 visible and clamps to the valid range, so GPIO up/down navigation gets correct
 scrolling for free.
 
+Rows are not all the same height: a wrapped label or subtitle grows one, so a
+layout routinely fits fewer indexes than `listVisibleRows()` estimates. Screens
+that scroll (swipe or button navigation) should therefore own a `ListNav` and
+call `nav.syncToProps(body, rowHeight, rowGap, count, props)` right before
+`list()`. `list()` reports the viewport it actually laid out back through
+`props.nav`, which gives the nav the real page size (`pageRows()`, the delta to
+page by) and lets it keep a clipped tail reachable. Because that feedback
+arrives only after a layout, a nav-managed screen must render in a small loop:
+
+```cpp
+for (int pass = 0; pass < 8; ++pass) {
+  app.render();
+  if (!nav.consumeRebuildNeeded()) break;
+}
+```
+
+Without the loop a clipped list can paint one frame with the selection or the
+scroll indicator missing. Callers repaint each pass over the previous one, so
+`list()` keeps the row geometry stable across the passes of a single render.
+
 ### Dialogs
 
 `optionDialog` composes a panel, up to three text slots, and a row (or

--- a/libs/ui/FreeInkUI/include/components/lists/list.h
+++ b/libs/ui/FreeInkUI/include/components/lists/list.h
@@ -170,6 +170,14 @@ struct ListNav {
   // yet). With variable-height rows this is the real page size, unlike the
   // fixed-height visibleRows estimate.
   int drawnRows = 0;
+  // props.count that drawnRows was measured against. A caller that reloads
+  // its data (a File Browser folder, a filtered list) keeps the same nav, so
+  // a measurement from a different row set must not be trusted as this list's
+  // page size. list() sets it alongside the feedback below. It only catches a
+  // reload that CHANGES the count: same-count new content (a rename, a
+  // re-sort) still inherits the old measurement, which is close enough
+  // because the next layout corrects it.
+  int drawnCount = 0;
   // A follow() is awaiting confirmation from onListRendered() that the
   // selection was actually drawn. Swipe scrolling (scrollBy) never sets this:
   // the selection is allowed off-screen there by design.
@@ -184,12 +192,30 @@ struct ListNav {
     visibleRows = 1;
     followOnBuild = true;
     drawnRows = 0;
+    drawnCount = 0;
     followPending = false;
     rebuildNeeded = false;
   }
 
+  // Whether drawnRows describes a layout of `count` rows.
+  bool trusts(const int count) const {
+    return drawnRows > 0 && (drawnCount == 0 || drawnCount == count);
+  }
+
   // Real rows per page once a build has run; the fixed-height estimate before.
+  // Unchecked: it trusts the last measurement whatever list it was taken on.
+  // Callers that know their current count should use pageRowsFor(count).
   int pageRows() const { return drawnRows > 0 ? drawnRows : visibleRows; }
+
+  // pageRows() for a caller that knows the list's current count: a
+  // measurement taken on a different count belongs to another row set, so it
+  // falls back to the estimate. Every clamp and page step (here, in list(),
+  // and in callers) must agree on this rule, or one of them scrolls to a
+  // viewport another one refuses to draw. drawnCount 0 means "not recorded"
+  // (a caller driving onListRendered() itself), which stays trusted.
+  int pageRowsFor(const int count) const {
+    return trusts(count) ? drawnRows : visibleRows;
+  }
 
 
   // Layout feedback from list(): the effective top it drew from, how many
@@ -232,7 +258,7 @@ struct ListNav {
   // tail rows unreachable (and fight onListRendered's follow correction).
   bool scrollBy(const int deltaRows, const int count) {
     const int pageSize =
-        drawnRows > 0 && drawnRows < visibleRows ? drawnRows : visibleRows;
+        trusts(count) && drawnRows < visibleRows ? drawnRows : visibleRows;
     int maxTop = count - pageSize;
     if (maxTop < 0)
       maxTop = 0;
@@ -319,7 +345,32 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       props.scrollIndicatorInset < 0 ? 0 : props.scrollIndicatorInset;
   const int16_t rowInset = props.rowInset < 0 ? 0 : props.rowInset;
   const uint16_t visible = listVisibleRows(rect, rowH, rowGap);
-  const bool overflows = props.count > visible;
+  // A nav-managed list reports how many indexes its last layout actually laid
+  // out. Variable-height rows (wrapped labels/subtitles) routinely fit fewer
+  // than the fixed-height `visible` estimate, so a list whose count is within
+  // that estimate can still be clipped. Treating it as non-overflowing would
+  // pin `top` at 0 below, discarding both swipe scrolling and the nav's
+  // follow correction: the clipped tail rows would be unreachable by any
+  // input, and the scroll indicator would never appear.
+  // The measurement only speaks for the row set it was taken on, so a caller
+  // that reloaded its data (same nav, new items) falls back to the estimate.
+  const bool measured =
+      props.nav != nullptr && props.nav->trusts(props.count);
+  const bool measuredClip = measured && props.nav->drawnRows < props.count;
+  const bool overflows = props.count > visible || measuredClip;
+  // Page size for the scroll indicator: the measured rows when the layout
+  // fits fewer than the estimate, so a clipped list still shows a thumb.
+  const uint16_t pageRows = measured && props.nav->drawnRows < visible
+                                ? static_cast<uint16_t>(props.nav->drawnRows)
+                                : visible;
+  // A nav-managed list always keeps the indicator's strip clear, whether or
+  // not this pass draws one. Its overflow state is discovered by measuring,
+  // so a strip that came and went would (a) leave the widened rows of an
+  // earlier pass on screen, because callers repaint the rebuild pass over the
+  // first one without clearing, and (b) measure the layout at a width the
+  // list does not always draw with, which can report a clip that full-width
+  // rows would not have had - and measuredClip then latches it.
+  const bool reserveScrollStrip = overflows || props.nav != nullptr;
   uint16_t top = props.topIndex;
   if (top > props.count - 1)
     top = props.count - 1;
@@ -337,22 +388,26 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       overflows ? static_cast<uint16_t>(top + visible) : props.count;
 
   Rect rowArea = rect;
+  // Width the reserved strip took from the rows, 0 when none was taken.
+  int16_t stripCut = 0;
   if (rowInset > 0) {
     rowArea.x = static_cast<int16_t>(rowArea.x + rowInset);
     rowArea.width = static_cast<int16_t>(rowArea.width - rowInset * 2);
   }
-  if (props.scrollIndicator && overflows && scrollW > 0) {
+  if (props.scrollIndicator && reserveScrollStrip && scrollW > 0) {
     // Rows only give up width when the row inset margin doesn't already
     // clear the track (plus its bezel inset) plus 2px of air.
     const int16_t needed = static_cast<int16_t>(scrollW + scrollInset + 2);
     if (rowInset < needed) {
-      const int16_t cut = static_cast<int16_t>(needed - rowInset);
-      rowArea.width = static_cast<int16_t>(rowArea.width - cut);
+      stripCut = static_cast<int16_t>(needed - rowInset);
+      rowArea.width = static_cast<int16_t>(rowArea.width - stripCut);
       if (scrollLeft)
-        rowArea.x = static_cast<int16_t>(rowArea.x + cut);
+        rowArea.x = static_cast<int16_t>(rowArea.x + stripCut);
     }
-    drawListScrollIndicator(frame.target(), rect, props.count, visible, top,
-                            scrollW, scrollLeft ? 1 : 0, scrollInset);
+    if (overflows) {
+      drawListScrollIndicator(frame.target(), rect, props.count, pageRows, top,
+                              scrollW, scrollLeft ? 1 : 0, scrollInset);
+    }
   }
 
   // Cursor-based layout: section header rows are shorter than item rows, so
@@ -516,8 +571,20 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
       // (findTouch skips disabled interactions).
       const State hitState = static_cast<State>(
           static_cast<int>(state) & ~static_cast<int>(StateDisabled));
-      frame.hit(
-          ensureMinTouchRect(row, frame.device().minTouchSize, frame.screen()),
+      // A reserved strip with no indicator in it is empty screen, so the row
+      // stays touchable across it: a nav list that fits would otherwise lose
+      // a band at the edge that no longer snaps back (ensureMinTouchRect only
+      // closes gaps under EDGE_SNAP_PX). Hugging rows keep their own width,
+      // and so does a drag-masked row, whose position maps through this rect.
+      Rect hitRow = row;
+      if (!overflows && stripCut > 0 && !props.hugContents &&
+          !acceptsInput(props.inputMask, InputDrag)) {
+        hitRow.width = static_cast<int16_t>(hitRow.width + stripCut);
+        if (scrollLeft)
+          hitRow.x = static_cast<int16_t>(hitRow.x - stripCut);
+      }
+      frame.hit(ensureMinTouchRect(hitRow, frame.device().minTouchSize,
+                                   frame.screen()),
           props.action, item.actionValue, props.inputMask, hitState);
     }
     state = frame.stateFor(props.action, item.actionValue, state);
@@ -722,8 +789,22 @@ void list(Frame<MaxInteractions> &frame, Rect rect, const ListProps &props) {
     }
   }
 
-  if (props.nav)
+  if (props.nav) {
+    // First build after a reset(): the nav had no measured page size yet, so
+    // the checks above ran on the fixed-height estimate alone. If this layout
+    // clipped a list that estimate called non-overflowing, ask for one rebuild
+    // so the same render pass repaints with the scroll indicator. The next
+    // pass has drawnRows > 0, so this cannot loop.
+    const bool clipDiscovered = props.nav->drawnRows == 0 &&
+                                consumedIndexes > 0 &&
+                                consumedIndexes < props.count &&
+                                props.count <= visible;
     props.nav->onListRendered(top, consumedIndexes, selectedDrawn);
+    if (consumedIndexes > 0)
+      props.nav->drawnCount = props.count;
+    if (clipDiscovered)
+      props.nav->rebuildNeeded = true;
+  }
 
   if (props.partialTrailingRow && visible > 0) {
     // First index the loop above did NOT lay out. With wrapped rows fewer

--- a/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
+++ b/libs/ui/FreeInkUI/test/host/test_freeinkui.cpp
@@ -996,6 +996,185 @@ void testListNavConvergesThroughRealList() {
   CHECK_EQ(nav.pageRows(), 6);
 }
 
+// A list whose count fits the FIXED-HEIGHT row estimate can still be clipped
+// once wrapped rows grow: 8 items with a 10-row estimate, but only 6 fit. The
+// pre-fix list() called that "no overflow" and pinned top at 0, so the clipped
+// tail was unreachable by swipe scrolling OR selection (the on-device File
+// Transfer menu at Large UI scale). Layout feedback must let the nav scroll.
+void testListNavScrollsClippedListWithinRowEstimate() {
+  FakeDrawTarget draw;
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+
+  static const char kLongLabel[] =
+      "wrapping filename that is deliberately long enough to need a second "
+      "display line";
+  ListItem items[8]{};
+  for (int i = 0; i < 8; ++i) {
+    items[i].label = kLongLabel;
+    items[i].actionValue = static_cast<int16_t>(i);
+    items[i].enabled = true;
+  }
+
+  const Rect body{0, 0, 480, 200};
+  CHECK_EQ(listVisibleRows(body, 20, 0), 10); // estimate exceeds the 8 items
+
+  ListNav nav;
+  nav.reset(0);
+
+  // One build pass over `count` items, returning whether the given index
+  // registered a hit rect. Each pass starts with an empty op log so the
+  // scroll-indicator assertions below see only that pass.
+  const auto buildCount = [&](const uint16_t count, const int16_t wantIndex) {
+    draw.opCount = 0;
+    InteractionBuffer<32> interactions;
+    Frame<32> frame(draw, device, input, interactions);
+    ListProps props;
+    props.items = items;
+    props.count = count;
+    props.action = 7;
+    props.rowHeight = 20;
+    props.labelText.maxLines = 2;
+    nav.syncToProps(body, 20, 0, count, props);
+    list(frame, body, props);
+    for (size_t k = 0; k < interactions.count(); ++k) {
+      if (interactions.data()[k].value == wantIndex)
+        return true;
+    }
+    return false;
+  };
+  const auto build = [&](const int16_t wantIndex) {
+    return buildCount(8, wantIndex);
+  };
+  // The scroll track and its thumb are the only 3px-wide fills at the band's
+  // right edge (scrollIndicatorWidth 3, no inset).
+  const auto scrollFills = [&]() {
+    int found = 0;
+    for (size_t k = 0; k < draw.opCount; ++k) {
+      const auto& op = draw.ops[k];
+      if (op.kind == FakeDrawTarget::Op::Fill && op.rect.x == 477 &&
+          op.rect.width == 3)
+        ++found;
+    }
+    return found;
+  };
+  const auto hasFill = [&](const Rect want) {
+    for (size_t k = 0; k < draw.opCount; ++k) {
+      const auto& op = draw.ops[k];
+      if (op.kind == FakeDrawTarget::Op::Fill && op.rect.x == want.x &&
+          op.rect.y == want.y && op.rect.width == want.width &&
+          op.rect.height == want.height)
+        return true;
+    }
+    return false;
+  };
+
+  build(0);
+  CHECK_EQ(nav.drawnRows, 6); // wrapped rows fit 6 of the estimated 10
+  CHECK_EQ(nav.drawnCount, 8);
+  CHECK_EQ(scrollFills(), 0); // nothing measured yet: no indicator on pass 1
+  // The first build had no measured page size, so it could not know the list
+  // was clipped; it asks for one repaint (which shows the scroll indicator).
+  CHECK(nav.consumeRebuildNeeded());
+  build(0);
+  CHECK(!nav.rebuildNeeded); // and does not ask again
+  CHECK_EQ(scrollFills(), 2); // the rebuild paints the track and its thumb
+  // Thumb sized by the MEASURED page (6 of 8), not the 10-row estimate: the
+  // estimate would make drawListScrollIndicator() drop the indicator entirely.
+  CHECK(hasFill(Rect{477, 0, 3, 150})); // 200 * 6 / 8, at top 0
+
+  // Swipe scrolling reaches the clipped tail instead of snapping back to 0.
+  CHECK(nav.scrollBy(nav.pageRows(), 8));
+  CHECK_EQ(nav.top, 2); // 8 items - 6 measured rows
+  CHECK(build(7));      // the last item draws and takes touches
+  CHECK_EQ(nav.top, 2); // list() kept the scrolled viewport
+  CHECK(hasFill(Rect{477, 50, 3, 150})); // thumb tracked the viewport
+
+  // The measurement belongs to the row set it was taken on. A caller that
+  // reloads its data keeps the same nav, and 7 items that all fit must not
+  // inherit the clipped list's page size (phantom indicator, narrowed rows).
+  buildCount(7, 0);
+  CHECK_EQ(scrollFills(), 0);
+
+  // Every clamp has to agree about that. scrollBy() pages by the estimate for
+  // the new count too: if it kept the old measured page it would leave `top`
+  // at a viewport list() refuses to draw, and a caller that already built its
+  // virtual item window from that top renders nothing at all.
+  nav.drawnRows = 6; // as measured on the 8-item list above
+  nav.drawnCount = 8;
+  nav.visibleRows = 10;
+  nav.top = 2;
+  CHECK(nav.scrollBy(0, 7)); // clamps to the estimate: 7 - 10 -> 0
+  CHECK_EQ(nav.top, 0);
+  CHECK_EQ(nav.pageRowsFor(7), 10); // estimate, not the stale 6
+  CHECK_EQ(nav.pageRowsFor(8), 6);  // the count it was measured on
+
+  // Selecting the last item converges too, from a viewport at the top.
+  ListNav tail;
+  tail.reset(7);
+  nav = tail;
+  int passes = 0;
+  bool lastRegistered = false;
+  for (; passes < 8; ++passes) {
+    lastRegistered = build(7);
+    if (!nav.consumeRebuildNeeded())
+      break;
+  }
+  CHECK(lastRegistered);
+  CHECK(!nav.followPending);
+  CHECK(passes < 8);
+}
+
+// A nav list reserves the scroll strip even when it fits, so rows draw a few
+// pixels short of the band edge. The touch rect must still cover that strip
+// while no indicator sits in it: with a bezel inset the gap is wider than
+// ensureMinTouchRect's edge snap, so the rows would otherwise stop short of
+// the screen edge on exactly the recessed-panel devices.
+void testListNavFittingListKeepsFullWidthTouchRects() {
+  FakeDrawTarget draw;
+  DeviceContext device = makeDevice();
+  InputSnapshot input;
+  InteractionBuffer<8> interactions;
+  Frame<8> frame(draw, device, input, interactions);
+
+  ListItem items[2]{};
+  for (int i = 0; i < 2; ++i) {
+    items[i].label = "row";
+    items[i].actionValue = static_cast<int16_t>(i);
+    items[i].enabled = true;
+  }
+
+  ListNav nav;
+  nav.reset(0);
+  ListProps props;
+  props.items = items;
+  props.count = 2;
+  props.action = 7;
+  props.rowHeight = 40;
+  props.scrollIndicatorInset = 7; // recessed panel: cut is 12, past the snap
+  const Rect body{0, 0, 480, 200};
+  nav.syncToProps(body, 40, 0, 2, props);
+  list(frame, body, props);
+
+  // Both rows fit, so no indicator is drawn and the strip is empty screen.
+  CHECK_EQ(nav.drawnRows, 2);
+  CHECK_EQ(interactions.count(), 2u);
+  for (size_t k = 0; k < interactions.count(); ++k) {
+    const Rect hit = interactions.data()[k].rect;
+    CHECK_EQ(hit.x, 0);
+    CHECK_EQ(hit.right(), 480); // reaches the band edge, strip included
+  }
+  // The row itself still stops short of the strip it reserved.
+  bool drewNarrowRow = false;
+  for (size_t k = 0; k < draw.opCount; ++k) {
+    const auto& op = draw.ops[k];
+    if (op.kind == FakeDrawTarget::Op::Fill && op.rect.height == 40 &&
+        op.rect.width == 468)
+      drewNarrowRow = true;
+  }
+  CHECK(drewNarrowRow);
+}
+
 void testListCanUseFullTitleWidthWithShortValue() {
   ListItem item{};
   item.label = "This filename is deliberately long enough to require a two-line wrapped title";
@@ -3642,6 +3821,8 @@ int main() {
   testListInlineSectionHeadingDoesNotOrphan();
   testListNavLayoutFeedback();
   testListNavConvergesThroughRealList();
+  testListNavScrollsClippedListWithinRowEstimate();
+  testListNavFittingListKeepsFullWidthTouchRects();
   testListCanUseFullTitleWidthWithShortValue();
   testListRtlMirrorsIconAndValueSides();
   testListRtlMirrorsToggleSide();


### PR DESCRIPTION
## Summary

Fix `ListNav`-managed lists when variable-height rows cause fewer items to fit than `listVisibleRows()` estimates.

Rows containing wrapped labels, subtitles, or section headings can exceed their nominal height. Previously, `list()` could decide that every item fit based on the fixed-height estimate, even though the actual layout clipped the final rows. It would then reset `topIndex` to `0`, discard swipe or button scrolling, and omit the scroll indicator.

This change:

- Uses the last measured layout to determine whether a nav-managed list overflows.
- Uses the measured page size for scrolling and the scroll-indicator thumb.
- Requests one rebuild when the first layout discovers previously unknown clipping.
- Associates measurements with the item count so stale measurements are not reused after a list changes.
- Keeps the scroll-indicator area geometrically stable between rebuild passes while preserving full-width touch targets when no indicator is displayed.
- Documents the required `ListNav` render/rebuild pattern.

## Motivation

This was exposed by [CrossInk issue #656](https://github.com/uxjulia/CrossInk/issues/656).

At Large UI scale, the File Transfer menu’s fixed-height estimate said all seven rows fit. Wrapped subtitles meant the real layout only fit six, leaving “Sync Stats” below the screen. `ListNav` measured the smaller viewport, but `list()` still classified the list as non-overflowing and reset every attempted scroll back to the first row.

The problem is in the shared list contract rather than the application’s swipe handler: a nav-managed list should use the viewport it actually laid out when determining whether its final rows are reachable.

## API changes

- Adds `ListNav::drawnCount`.
- Adds `ListNav::trusts(count)`.
- Adds `ListNav::pageRowsFor(count)` for callers whose list size can change.
- Keeps `pageRows()` available for callers that intentionally use the most recent measurement without validating its count.

## Compatibility

Lists without a `ListNav` retain the existing fixed-height overflow behavior.

Nav-managed lists reserve a stable scroll-indicator strip across measurement/rebuild passes. When the list does not overflow, row touch targets still extend across that unused strip.

## Testing

Ran:

```sh
libs/ui/FreeInkUI/test/host/run.sh