### PR TITLE
fix: count Home key input as touch activity

### DIFF
--- a/libs/hardware/InputManager/include/InputManager.h
+++ b/libs/hardware/InputManager/include/InputManager.h
@@ -169,10 +169,10 @@ class InputManager {
   // Self-clears; async tap, single-swipe, multi-touch-swipe, and rotation
   // queues are gated by the same latch.
   void suppressTouchContact();
-  // True if a touch press or release happened this frame. Coarse "the user
-  // touched the screen" signal (the touch analogue of wasAnyPressed/Released)
-  // for resetting idle/sleep timers and restoring CPU frequency. False on
-  // non-touch boards.
+  // True if a screen-touch press/release or standalone capacitive home-key
+  // event happened this frame. Coarse touch-input signal (the touch analogue
+  // of wasAnyPressed/Released) for resetting idle/sleep timers and restoring
+  // CPU frequency. False on non-touch boards.
   bool wasTouchActivity() const;
   // True on the press edge of the GT911 capacitive home key (controllers
   // without one never report it). Cleared each #update().

--- a/libs/hardware/InputManager/src/InputManager.cpp
+++ b/libs/hardware/InputManager/src/InputManager.cpp
@@ -715,7 +715,11 @@ unsigned long InputManager::lastTouchHeldMs() const {
 
 bool InputManager::wasTouchActivity() const {
 #if FREEINK_CAP_TOUCH
-  return touchPressedEvent || touchReleasedEvent;
+  const bool screenActivity = touchPressedEvent || touchReleasedEvent;
+  const bool homeKeyActivity = touchHomeKeyEvent || touchHomeKeyTapEvent || touchHomeKeyLongEvent;
+  // A held screen contact already owns this activity lifecycle. Do not let a
+  // simultaneous Home-key edge retire screen-contact suppression early.
+  return screenActivity || (!touchPressed && homeKeyActivity);
 #else
   return false;
 #endif


### PR DESCRIPTION
## Summary

- Include capacitive Home-key press, short-tap, and long-press events in `InputManager::wasTouchActivity()`.
- Preserve screen-contact suppression when Home is pressed while a screen touch remains held.

## Why

Crossink users can set a Home key shortcut to page turn, but since it wasn't registering as activity, their device could still be put to sleep after an elapsed period of time.

This updates `wasTouchActivity()` to recognize Home-key presses as well so that the inactivity timer is properly extended.