### PR TITLE
feat: add Waveshare ESP32-S3-ePaper-3.97 board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ so the SD manager itself stays device-agnostic.
 | **Xteink X4 Pro** | ESP32-S3 | SSD1677, UC8179, **or UC8279** (per batch) | 800×480 B/W | GT911 touch, dual warm/cold frontlight, native 1-bit SDMMC, BM8563 RTC, CW2017 battery gauge; controller auto-detected at boot |
 | **Xteink X4 Classic** (X4C) | ESP32-S3 | SSD1677, UC8179, **or UC8279** (per unit) | 800×480 B/W | same board/glass as the X4 Pro but **no touch, no frontlight** — those pins become four extra discrete front buttons (8 buttons total); native 1-bit SDMMC, BM8563 RTC, CW2017 battery gauge; controller auto-detected at boot |
 | **M5Stack Paper Mono** | ESP32-S3 | SSD1677 | 800×480 B/W | non-flashing fast refresh + 3-level grayscale (host-authored LUTs), FT6336 touch, PMIC-PWM frontlight (AW9967), RX8130 RTC, PDM microphone, LEDC buzzer, discrete RGB LED, native 1-bit SDMMC, M5PM1 battery/charging telemetry; power/reset rails sequenced through the on-board M5PM1 PMIC + M5IOE1 expander |
+| **Waveshare ESP32-S3-ePaper-3.97** | ESP32-S3 | SSD1677 | 3.97" 800×480 B/W | reuses the SSD1677 driver with the Sticky's vendor sequences, 3 side keys + BOOT (no touch), native 4-bit SDMMC, AXP2101 PMIC as EPD rail + battery gauge + power key, PCF85063 RTC, QMI8658 IMU; orientation pending hardware validation — see docs/waveshare-epaper-397-support.md |
 | **M5Stack PaperS3** | ESP32-S3 | ED047TC1 (raw parallel) | 960×540 16-gray | same LovyanGFX EPD driver class as the LilyGo T5 S3 (plain-GPIO EPD rails, no PMIC), GT911 touch (touch-only navigation — no GPIO buttons), BM8563 RTC, GPIO3 ADC battery, LEDC buzzer, SPI MicroSD; power-off is a GPIO44 pulse to the PMS150G latch (`BoardPaperS3::powerOff()`); rotation/touch-flip pending hardware validation |
 
 X3 and X4 share the ESP32-C3 and a pinout, so **one firmware binary drives both**:
@@ -147,7 +148,7 @@ profile. In builds without an Xteink profile the helpers compile to no-ops that
 return false without touching any pins, so an unconditional call is safe on
 every device. Devices on a different MCU build their own binary, selected with a
 `-DFREEINK_DEVICE_*` flag. A build targets exactly one of the four MCU families — ESP32-C3 (X3/X4),
-ESP32-C61 (OnePage), ESP32-S3 (de-link/PaperColor/Murphy/LilyGo/Sticky/X4 Pro/Paper Mono/PaperS3), or classic ESP32 (M5Paper);
+ESP32-C61 (OnePage), ESP32-S3 (de-link/PaperColor/Murphy/LilyGo/Sticky/X4 Pro/Paper Mono/PaperS3/Waveshare 3.97), or classic ESP32 (M5Paper);
 `BoardConfig` rejects mixing families at compile time.
 
 #### Per-batch panel controllers (`applyXteinkDisplayController()`)

--- a/docs/waveshare-epaper-397-support.md
+++ b/docs/waveshare-epaper-397-support.md
@@ -1,0 +1,120 @@
+# Waveshare ESP32-S3-ePaper-3.97 support
+
+`-DFREEINK_DEVICE_WS397=1` (`Board::WsEpaper397`, profile name `ws397`).
+
+An ESP32-S3-WROOM-1-N16R8 carrier for a 3.97" 800x480 B/W e-paper panel, with an
+AXP2101 PMIC, 4-bit SDMMC card slot, three side keys, PCF85063 RTC, QMI8658 IMU,
+SHTC3 temp/humidity sensor and an ES8311 audio codec.
+
+Product page: <https://www.waveshare.com/esp32-s3-epaper-3.97.htm> ·
+Wiki: <https://docs.waveshare.com/ESP32-S3-ePaper-3.97>
+
+## Pin evidence
+
+Everything below comes from the vendor's own sources
+(<https://github.com/waveshareteam/ESP32-S3-ePaper-3.97>), not from a datasheet
+guess:
+
+| Function | Pins | Source |
+|---|---|---|
+| EPD SPI | SCK 11, MOSI 12, CS 10, DC 9, RST 46, BUSY 3 | `Arduino/examples/02_E-Paper_Example/DEV_Config.h`, `ESP-IDF/08_.../components/epaper_port/epaper_port.h` |
+| EPD SPI clock | 20 MHz | `epaper_port.c` (`clock_speed_hz`) |
+| EPD power rail | AXP2101 **ALDO3** | `components/epaper_port/epaper_port.c` (`enapwrstate(ALDO3)`) |
+| SD (SDMMC) | CLK 16, CMD 17, D0 15, D1 7, D2 8, D3 18 (4-bit) | `components/sdcard_bsp/sdcard_bsp.c` |
+| Buttons | UP 4, OK 5, DOWN 6, BOOT 0 — all active-low | `components/button_bsp/button_bsp.c` |
+| PMIC interrupt | GPIO38, active-low | NOT in the vendor sources — identified by probing during bring-up |
+| Deep-sleep wake | GPIO0 | `Arduino/examples/.../user_config.h` (`ext_wakeup_pin_1`) |
+| I2C bus | SDA 41, SCL 42 | `user_config.h` |
+| PMIC | AXP2101 @ 0x34 | `components/axpPower/axp_prot.cpp` |
+| RTC | PCF85063 @ 0x51 | `user_config.h` |
+| Temp/humidity | SHTC3 @ 0x70 | `user_config.h` |
+| IMU | QMI8658 (0x6B, 0x6A alt) | `components/qmi8658_bsp` |
+| Audio | ES8311: MCLK 13, BCK 14, WS 47, DIN 21, DOUT 48, PA 39 | `components/es8311_bsp/es8311_bsp.h` |
+
+## Panel
+
+The controller is SSD1677-class and the vendor bring-up is byte-identical to the
+Seeed Sticky's — booster `AE C7 C3 C0 80`, driver output scan `0x02`, data entry
+`0x01`, border `0x01`, and update sequences `0x22 = F7` (full) / `FF` (partial) /
+`D7` (fast). `ssd1677ActiveConfig()` therefore returns `ssd1677StickyConfig()` for
+this board, including its grayscale LUT.
+
+## AXP2101 (Axp2101.h)
+
+The PMIC is load-bearing, not an accessory:
+
+* **ALDO3 is the e-paper rail.** The panel is dead until it is enabled, so
+  `EpdBus::begin()` calls `axp2101::setEpdPower(true)` through the board hook
+  (the profile's `display.powerEnable` stays unassigned), and
+  `PowerManager::powerDownRailsForSleep()` drops it before deep sleep.
+* **It is the only battery telemetry** — no ADC divider, no gauge chip.
+  `GaugeType::Axp2101` reads SoC (0xA4), VBAT (0x34/0x35) and charge state
+  (0x01[7:5]).
+* **It owns the power key.** PWRKEY does a hardware 1 s power-on / 4 s power-off
+  that firmware never sees, and `axp2101::shutdown()` (COMMON_CONFIG[0]) is a full
+  software power-off.
+
+## Buttons
+
+Four usable keys: the three-way side rocker (UP 4 / OK 5 / DOWN 6) plus BOOT
+(GPIO0). BOOT is both Back and the power button — hold to sleep, press to wake —
+because it is the pin the vendor arms for deep-sleep wake and the only key that can
+serve as one.
+
+There are no Left/Right keys, so `KeyboardEntryActivity` falls back to walking the
+key grid in reading order with Up/Down (`hasHorizontalKeys()`); every key stays
+reachable from one button pair. That fallback keys off the profile, so it switches
+itself off on any board that does wire a horizontal key.
+
+### The case-labelled PWR key is not wired to the CPU (as far as bring-up could tell)
+
+The board has a fifth, PWR-labelled key that the firmware cannot see. It is absent
+from the vendor's `button_bsp.c`, and a bring-up probe that watched every unclaimed
+GPIO (1, 2, 13, 14, 21, 38, 39, 40, 45, 47, 48) plus the AXP2101 interrupt-status
+registers caught nothing while the key was pressed — including no `PKEY` bits in
+`INTSTS2` with the PWRKEY short-press interrupt enabled. Holding it past the
+PMIC's 4 s power-off time did not cut power either (the board was on USB).
+
+Do NOT map GPIO38 as that key. It carries the AXP2101's active-low interrupt
+output, which sits LOW for as long as any PMIC interrupt is pending — a gauge
+"new SoC" interrupt during the probe read as a 55 ms button press, and mapping the
+pin as a key reads as one held down forever. That line is useful, just not as a
+button: it is how a future change could react to PMIC events without polling.
+
+Pins deliberately left out of that probe, and therefore still unchecked: 19/20
+(native USB), 33-37 (octal PSRAM), 43/44 (UART).
+
+## Flashing
+
+The board powers itself down a few seconds after reset unless firmware is running
+and holding the PMIC, so a plain `pio run -t upload` loses the port mid-write.
+Flash with the chip parked in the ROM downloader (`esptool --after no-reset`), or
+in slices that resume across power cuts. Once CrossPoint is running it calls
+`axp2101::ensureBooted()` and the board stays up normally.
+
+## Confirmed on hardware
+
+Bring-up on a unit, reading an EPUB end to end:
+
+* Panel bring-up through the PMIC rail: `EpdBus` -> `axp2101::setEpdPower(true)` ->
+  SSD1677 responds, full refresh in 2.08 s.
+* `NO_FLIP` is the correct mount orientation — text renders upright.
+* PCF85063 RTC answers (`[CLK] SDK RTC found`).
+* 4-bit SDMMC mounts and carries the section cache under `/.crosspoint/`.
+* Buttons page through a book; BOOT wakes the board out of deep sleep without
+  falling into the ROM downloader, so GPIO0 doubling as Back/power holds up.
+* Grayscale renders (`planes buffered: 2`), ~910 ms per page turn.
+* ~240 KB of 329 KB heap free while reading (219 KB low-water).
+
+## Pending hardware validation
+
+* **Grayscale LUT** — reused from the Sticky; retune if a unit shows banding on
+  covers.
+* **Battery curve** — the AXP2101 fuel gauge learns its curve at runtime; SoC may
+  be coarse until it has seen a full charge cycle.
+* **SPI clock** — 20 MHz is the vendor value and it is NOT worth raising: a page
+  turn measures `wait=407ms` (BW waveform) + `gray_display=226ms` against
+  `display=24ms` of actual SPI traffic, so the 40 MHz default would save ~10 ms of
+  910. The panel's waveforms are the floor here, not the bus.
+* SHTC3 has no `EnvironmentSensor` backend yet (`tempHumidityAddr` is left 0), and
+  the ES8311 codec / NS4150B amp are wired but unused (`NO_AUDIO`).

--- a/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
+++ b/libs/display/FreeInkDisplay/src/bus/EpdBus.cpp
@@ -8,6 +8,9 @@
 #if FREEINK_DEVICE_PAPERMONO
 #include <PaperMonoBoard.h>
 #endif
+#if FREEINK_DEVICE_WS397
+#include <Axp2101.h>
+#endif
 
 // Consumer escape hatch for boards whose EPD power/reset live behind glue the
 // SDK doesn't know. Weak REFERENCES only — an SDK-internal implementation
@@ -23,12 +26,14 @@ namespace {
 void boardEpdPower(bool enabled) {
 #if FREEINK_DEVICE_PAPERMONO
   freeink::papermono::setEpdPower(enabled);
+#elif FREEINK_DEVICE_WS397
+  freeink::axp2101::setEpdPower(enabled);  // ALDO3, not a GPIO
 #else
   if (freeink_board_epd_power) freeink_board_epd_power(enabled);
 #endif
 }
 bool boardEpdPowerAvailable() {
-#if FREEINK_DEVICE_PAPERMONO
+#if FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_WS397
   return true;
 #else
   return freeink_board_epd_power != nullptr;

--- a/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.cpp
@@ -672,6 +672,11 @@ static const Ssd1677Config& ssd1677ActiveConfig() { return FREEINK_SSD1677_CONFI
 static const Ssd1677Config& ssd1677ActiveConfig() {
   switch (BoardConfig::ACTIVE.board) {
     case BoardConfig::Board::Sticky: return ssd1677StickyConfig();
+    // Waveshare ESP32-S3-ePaper-3.97: the vendor driver's bring-up is byte-identical
+    // to Seeed's (booster AE C7 C3 C0 80, border 0x01, 0x22 = F7 full / FF partial /
+    // D7 fast), so it runs the same config. Grayscale LUT is Sticky's — same panel
+    // class, but tune here if a unit shows banding.
+    case BoardConfig::Board::WsEpaper397: return ssd1677StickyConfig();
     // X4 Pro runs on the stock X4/GDEQ0426T82 config — same controller and panel
     // class, confirmed painting on hardware. No custom LUT or drive voltages needed.
     // Layers the fast-DU shortcut only when the build opts in (ssd1677X4ProConfig).

--- a/libs/hardware/BatteryMonitor/src/BatteryMonitor.cpp
+++ b/libs/hardware/BatteryMonitor/src/BatteryMonitor.cpp
@@ -13,6 +13,9 @@
 
 #if FREEINK_BATTERY_I2C_GAUGE
 #include <Wire.h>
+#if FREEINK_DEVICE_WS397
+#include <Axp2101.h>
+#endif
 
 // Minimal, dependency-free I2C fuel-gauge read for boards that carry one (e.g.
 // LilyGo T5 S3: BQ27220 gauge + BQ25896 charger). Standard TI command registers;
@@ -205,6 +208,14 @@ bool cw2017EnsureProfile(const uint8_t addr) {
 // SoC (0..100) from the active gauge, dispatched by type. false on I2C failure.
 bool readGaugeSoc(uint16_t& out) {
   const auto& g = BoardConfig::ACTIVE.batteryGauge;
+#if FREEINK_DEVICE_WS397
+  if (g.gaugeType == BoardConfig::GaugeType::Axp2101) {
+    uint8_t soc = 0;
+    if (!freeink::axp2101::batteryPercent(soc)) return false;
+    out = soc;
+    return true;
+  }
+#endif
   if (g.gaugeType == BoardConfig::GaugeType::Cw2017) {
     static bool initialized = false;
     static unsigned long lastInitAttemptMs = 0;
@@ -241,6 +252,9 @@ bool readGaugeSoc(uint16_t& out) {
 // Battery voltage (mV) from the active gauge, dispatched by type. false on failure.
 bool readGaugeMillivolts(uint16_t& out) {
   const auto& g = BoardConfig::ACTIVE.batteryGauge;
+#if FREEINK_DEVICE_WS397
+  if (g.gaugeType == BoardConfig::GaugeType::Axp2101) return freeink::axp2101::batteryMillivolts(out);
+#endif
   if (g.gaugeType == BoardConfig::GaugeType::Cw2017) {
     uint8_t hi = 0, lo = 0;
     if (!readReg8(g.gaugeAddr, CW2017_REG_VCELL_H, hi)) return false;
@@ -268,6 +282,9 @@ bool readGaugeMillivolts(uint16_t& out) {
 // a board with neither gaugeAddr nor chargerAddr).
 bool readGaugeCharging(bool& known) {
   const auto& g = BoardConfig::ACTIVE.batteryGauge;
+#if FREEINK_DEVICE_WS397
+  if (g.gaugeType == BoardConfig::GaugeType::Axp2101) return freeink::axp2101::isCharging(known);
+#endif
   // CW2017 has no current register and the X4 Pro has no charger IC on this bus, so
   // charging state is not observable from the gauge (the OEM infers it elsewhere).
   if (g.gaugeType == BoardConfig::GaugeType::Cw2017) {

--- a/libs/hardware/BoardConfig/include/Axp2101.h
+++ b/libs/hardware/BoardConfig/include/Axp2101.h
@@ -1,0 +1,150 @@
+#pragma once
+
+// X-Powers AXP2101 PMIC — board support for the Waveshare ESP32-S3-ePaper-3.97.
+//
+// On that board the PMIC is not an optional extra: ALDO3 is the e-paper rail
+// (the panel is dead until it is enabled), and the PMIC's fuel-gauge block is
+// the only battery telemetry — there is no ADC divider and no gauge chip. Two
+// SDK modules therefore talk to it (EpdBus for the rail, BatteryMonitor for the
+// gauge), so the register map and the bus live here, once.
+//
+// Register semantics follow the AXP2101 datasheet, cross-checked against the
+// vendor demo's XPowersLib usage (components/axpPower in
+// waveshareteam/ESP32-S3-ePaper-3.97).
+//
+// Header-only inline I2C, same pattern as M5Pm1.h: both callers already depend
+// on BoardConfig, so no extra lib wiring.
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "BoardConfig.h"
+
+namespace freeink {
+namespace axp2101 {
+
+// --- registers ---
+constexpr uint8_t REG_STATUS1 = 0x00;        // [5] VBUS good, [3] battery present
+constexpr uint8_t REG_STATUS2 = 0x01;        // [7:5] charge state (001 = charging)
+constexpr uint8_t REG_COMMON_CONFIG = 0x10;  // [0] soft power-off
+constexpr uint8_t REG_ADC_CHANNEL_CTRL = 0x30;  // [0] VBAT ADC enable
+constexpr uint8_t REG_VBAT_H = 0x34;            // 13-bit VBAT in mV, H5L8 over 0x34/0x35
+constexpr uint8_t REG_LDO_ONOFF_CTRL0 = 0x90;   // [2] ALDO3 enable
+constexpr uint8_t REG_ALDO3_VOL = 0x94;         // [4:0] (mV - 500) / 100
+constexpr uint8_t REG_FUEL_GAUGE_CTRL = 0xA2;   // [0] gauge enable
+constexpr uint8_t REG_BAT_PERCENT = 0xA4;       // SoC, whole percent
+
+constexpr uint8_t ALDO3_BIT = 1 << 2;
+constexpr uint8_t GAUGE_EN_BIT = 1 << 0;
+constexpr uint8_t VBAT_ADC_EN_BIT = 1 << 0;
+constexpr uint8_t POWEROFF_BIT = 1 << 0;
+constexpr uint8_t STATUS1_VBUS_GOOD = 1 << 5;
+constexpr uint8_t ALDO3_VOL_3V3 = (3300 - 500) / 100;  // REG_ALDO3_VOL code for 3.3 V
+
+namespace detail {
+
+inline uint8_t address() { return BoardConfig::ACTIVE.batteryGauge.gaugeAddr; }
+
+// The PMIC shares the board's only I2C bus with the RTC/IMU, so the pins come
+// from the profile rather than a private define. begin() is idempotent in the
+// Arduino core; other users of the bus (Rtc, Imu) call it with the same values.
+inline void beginBus() {
+  const auto& g = BoardConfig::ACTIVE.batteryGauge;
+  static bool started = false;
+  if (started) return;
+  started = true;
+  Wire.begin(g.i2cSda, g.i2cScl, g.i2cHz);
+}
+
+inline bool readReg(uint8_t reg, uint8_t& out) {
+  beginBus();
+  Wire.beginTransmission(address());
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) return false;
+  if (Wire.requestFrom(address(), static_cast<uint8_t>(1), static_cast<uint8_t>(true)) < 1) return false;
+  out = Wire.read();
+  return true;
+}
+
+inline bool writeReg(uint8_t reg, uint8_t value) {
+  beginBus();
+  Wire.beginTransmission(address());
+  Wire.write(reg);
+  Wire.write(value);
+  return Wire.endTransmission(true) == 0;
+}
+
+inline bool updateReg(uint8_t reg, uint8_t clearMask, uint8_t setMask) {
+  uint8_t value = 0;
+  if (!readReg(reg, value)) return false;
+  const uint8_t updated = static_cast<uint8_t>((value & ~clearMask) | setMask);
+  if (updated == value) return true;
+  return writeReg(reg, updated);
+}
+
+}  // namespace detail
+
+// One-time bring-up (idempotent, cheap after the first call): battery voltage
+// ADC and the fuel gauge on, ALDO3 pinned to 3.3 V. Rail enable itself is left
+// to setEpdPower() so a board that sleeps with the panel off stays off.
+inline bool ensureBooted() {
+  static bool booted = false;
+  static bool ok = false;
+  if (booted) return ok;
+  booted = true;
+  if (detail::address() == 0) return false;
+  ok = detail::updateReg(REG_ADC_CHANNEL_CTRL, 0, VBAT_ADC_EN_BIT) &&
+       detail::updateReg(REG_FUEL_GAUGE_CTRL, 0, GAUGE_EN_BIT) &&
+       detail::updateReg(REG_ALDO3_VOL, 0x1F, ALDO3_VOL_3V3);
+  return ok;
+}
+
+// EPD rail (ALDO3). EpdBus's own 100 ms settle covers power-on.
+inline void setEpdPower(bool enabled) {
+  ensureBooted();
+  detail::updateReg(REG_LDO_ONOFF_CTRL0, enabled ? 0 : ALDO3_BIT, enabled ? ALDO3_BIT : 0);
+}
+
+// SoC in whole percent. false when the PMIC does not answer.
+inline bool batteryPercent(uint8_t& out) {
+  if (!ensureBooted()) return false;
+  uint8_t soc = 0;
+  if (!detail::readReg(REG_BAT_PERCENT, soc)) return false;
+  if (soc > 100) return false;  // 0xFF while the gauge is still settling
+  out = soc;
+  return true;
+}
+
+inline bool batteryMillivolts(uint16_t& out) {
+  if (!ensureBooted()) return false;
+  uint8_t hi = 0, lo = 0;
+  if (!detail::readReg(REG_VBAT_H, hi) || !detail::readReg(static_cast<uint8_t>(REG_VBAT_H + 1), lo)) return false;
+  out = static_cast<uint16_t>((hi & 0x1F) << 8) | lo;  // already millivolts
+  return true;
+}
+
+// Charge state from STATUS2[7:5]; 001 = charging.
+inline bool isCharging(bool& known) {
+  uint8_t status = 0;
+  if (!ensureBooted() || !detail::readReg(REG_STATUS2, status)) {
+    known = false;
+    return false;
+  }
+  known = true;
+  return ((status >> 5) & 0x07) == 0x01;
+}
+
+inline bool isVbusPresent() {
+  uint8_t status = 0;
+  if (!ensureBooted() || !detail::readReg(REG_STATUS1, status)) return false;
+  return (status & STATUS1_VBUS_GOOD) != 0;
+}
+
+// Full power-off (the PMIC drops every rail). A PWRKEY press boots the board again.
+inline bool shutdown() {
+  if (!ensureBooted()) return false;
+  return detail::updateReg(REG_COMMON_CONFIG, 0, POWEROFF_BIT);
+}
+
+}  // namespace axp2101
+}  // namespace freeink

--- a/libs/hardware/BoardConfig/include/BoardConfig.h
+++ b/libs/hardware/BoardConfig/include/BoardConfig.h
@@ -75,14 +75,17 @@
 #ifndef FREEINK_DEVICE_ONEPAGE
 #define FREEINK_DEVICE_ONEPAGE 0
 #endif
+#ifndef FREEINK_DEVICE_WS397
+#define FREEINK_DEVICE_WS397 0
+#endif
 
 // --- 2) Coherence: exactly one MCU family, at least one device ---------------
 #if !(FREEINK_DEVICE_X4 || FREEINK_DEVICE_X3 || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_M5 || \
       FREEINK_DEVICE_MURPHY || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_M5PAPER ||               \
       FREEINK_DEVICE_STICKY || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_MURPHY_M4 ||         \
-      FREEINK_DEVICE_EEGO_A4 || FREEINK_DEVICE_ONEPAGE)
+      FREEINK_DEVICE_EEGO_A4 || FREEINK_DEVICE_ONEPAGE || FREEINK_DEVICE_WS397)
 #error \
-    "FreeInk: no device selected. Pass at least one -DFREEINK_DEVICE_<NAME> (X4, X3, X4PRO, X4CLASSIC, M5, MURPHY, DELINK, LILYGO, M5PAPER, STICKY, PAPERMONO, PAPERS3, MURPHY_M4, EEGO_A4, ONEPAGE) in your build env — see platformio.sample.ini."
+    "FreeInk: no device selected. Pass at least one -DFREEINK_DEVICE_<NAME> (X4, X3, X4PRO, X4CLASSIC, M5, MURPHY, DELINK, LILYGO, M5PAPER, STICKY, PAPERMONO, PAPERS3, MURPHY_M4, EEGO_A4, ONEPAGE, WS397) in your build env — see platformio.sample.ini."
 #endif
 // Each device belongs to one MCU family; a binary targets exactly one. X3/X4 are
 // ESP32-C3; M5 PaperColor/Murphy/de-link/LilyGo are ESP32-S3; M5Paper v1.1 is the
@@ -93,7 +96,7 @@
 #define FREEINK_MCU_S3                                                                                    \
   (FREEINK_DEVICE_M5 || FREEINK_DEVICE_MURPHY || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_LILYGO ||        \
    FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_PAPERMONO ||  \
-   FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_MURPHY_M4 || FREEINK_DEVICE_EEGO_A4)
+   FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_MURPHY_M4 || FREEINK_DEVICE_EEGO_A4 || FREEINK_DEVICE_WS397)
 #define FREEINK_MCU_ESP32 (FREEINK_DEVICE_M5PAPER)
 #if (FREEINK_MCU_C3 + FREEINK_MCU_C61 + FREEINK_MCU_S3 + FREEINK_MCU_ESP32) != 1
 #error \
@@ -108,7 +111,7 @@
 // use SSD1677, UC8179, or UC8279, recovered from OEM firmware and hardware
 // references — see docs/xteink-x4pro-support.md.
 #if FREEINK_DEVICE_X4 || FREEINK_DEVICE_DELINK || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || \
-    FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_MURPHY_M4 || FREEINK_DEVICE_ONEPAGE
+    FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_MURPHY_M4 || FREEINK_DEVICE_ONEPAGE || FREEINK_DEVICE_WS397
 #define FREEINK_DRIVER_SSD1677 1
 #else
 #define FREEINK_DRIVER_SSD1677 0
@@ -260,7 +263,7 @@
 #ifndef FREEINK_BATTERY_I2C_GAUGE
 #define FREEINK_BATTERY_I2C_GAUGE                                                            \
   (FREEINK_DEVICE_X3 || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || \
-   FREEINK_DEVICE_X4CLASSIC)
+   FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_WS397)
 #endif
 #ifndef FREEINK_CAP_COLOR
 #define FREEINK_CAP_COLOR (FREEINK_DEVICE_M5)
@@ -279,13 +282,15 @@
 #ifndef FREEINK_CAP_RTC
 #define FREEINK_CAP_RTC                                                                             \
   (FREEINK_DEVICE_X3 || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || \
-   FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_EEGO_A4)
+   FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_PAPERS3 || FREEINK_DEVICE_LILYGO || FREEINK_DEVICE_EEGO_A4 || \
+   FREEINK_DEVICE_WS397)
 #endif
 #ifndef FREEINK_CAP_TEMP_HUMIDITY
 #define FREEINK_CAP_TEMP_HUMIDITY (FREEINK_DEVICE_STICKY)
 #endif
 #ifndef FREEINK_CAP_IMU
-#define FREEINK_CAP_IMU (FREEINK_DEVICE_X3 || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4CLASSIC)
+#define FREEINK_CAP_IMU \
+  (FREEINK_DEVICE_X3 || FREEINK_DEVICE_STICKY || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_WS397)
 #endif
 // LEDC PWM buzzer (tone beeper). The Buzzer lib drives the AudioConfig.buzzer
 // pin; on for boards that wire one (Sticky GPIO48, Murphy GPIO46, PaperS3
@@ -324,7 +329,7 @@
 #ifndef FREEINK_SD_SDMMC
 #define FREEINK_SD_SDMMC                                                                            \
   (FREEINK_DEVICE_DELINK || FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_PAPERMONO || \
-   FREEINK_DEVICE_MURPHY_M4)
+   FREEINK_DEVICE_MURPHY_M4 || FREEINK_DEVICE_WS397)
 #endif
 
 // Serial log transport hint for consumer firmware. Boards can share the same MCU
@@ -381,6 +386,7 @@ enum class Board : uint8_t {
   M5PaperS3,  // ESP32-S3 sibling of M5Paper v1.1: same ED047TC1 glass, no IT8951 — raw parallel via LovyanGFX
   EegoA4,     // EEGO Reader A4: ESP32-S3, UC8279C 768x552 SPI panel, GSLX680 touch, PCF8563 RTC
   OnePage,    // OnePage: ESP32-C61, SSD1677 800x480 SPI panel, 4-key ADC ladder + 3 side keys
+  WsEpaper397,  // Waveshare ESP32-S3-ePaper-3.97: SSD1677 800x480, 3 keys + BOOT, AXP2101 PMIC
 };
 
 // How the board reports button presses.
@@ -474,7 +480,9 @@ struct SdmmcPins {
 // init, so BatteryMonitor dispatches on it. Bq27220: TI command registers, no profile
 // upload (LilyGo/X3). Cw2017: CellWise gauge that needs an 80-byte BATINFO battery
 // profile loaded before it reports a valid SoC (Xteink X4 Pro).
-enum class GaugeType : uint8_t { Bq27220, Cw2017 };
+// Axp2101: not a gauge chip but a PMIC whose fuel-gauge block reports SoC directly
+// (Waveshare ESP32-S3-ePaper-3.97). Its registers live in Axp2101.h.
+enum class GaugeType : uint8_t { Bq27220, Cw2017, Axp2101 };
 
 // I2C fuel-gauge / charger wiring (e.g. BQ27220 + BQ25896 on LilyGo T5 S3). When
 // gaugeAddr != 0 (and FREEINK_BATTERY_I2C_GAUGE is set), BatteryMonitor reads the
@@ -628,7 +636,7 @@ struct MicConfig {
   bool enableActiveHigh;
 };
 
-enum class RtcType : uint8_t { None, Pcf8563, Ds3231, Rx8130 };
+enum class RtcType : uint8_t { None, Pcf8563, Ds3231, Rx8130, Pcf85063 };
 enum class ImuType : uint8_t { None, Lsm6ds3, Qmi8658 };
 
 // On-board I2C sensors sharing one bus (e.g. the Sticky's RTC + temp/humidity +
@@ -1483,6 +1491,69 @@ constexpr BoardProfile STICKY = {
     // (~0.06 A USB input awake vs ~0.5 A once sleep isolates the pad).
     {45, 46, 39, false}};
 
+// --- Waveshare ESP32-S3-ePaper-3.97 — ESP32-S3-WROOM-1-N16R8, SSD1677 800x480 --
+// Pins come from the vendor demo sources (waveshareteam/ESP32-S3-ePaper-3.97):
+// Arduino/examples DEV_Config.h + 05_SD_Test, and ESP-IDF/08_.../components
+// (epaper_port, sdcard_bsp, button_bsp, user_config.h).
+//
+// The panel is the same SSD1677 800x480 class as the X4 / Sticky, and the vendor
+// bring-up is byte-identical to Sticky's (booster AE C7 C3 C0 80, scan 0x02, data
+// entry 0x01, update sequences 0xF7 full / 0xFF partial), so the driver reuses
+// ssd1677StickyConfig().
+//
+// The EPD rail is NOT a GPIO: it hangs off the AXP2101 PMIC's ALDO3, and the same
+// PMIC is the battery gauge and the power button. Axp2101.h owns that bus; EpdBus
+// and BatteryMonitor call into it.
+//
+// Buttons: three side keys (UP 4 / OK 5 / DOWN 6) plus BOOT (GPIO0), all
+// active-low. BOOT doubles as Back and as the deep-sleep wake pin — hold it to
+// sleep, press it to wake. The PMIC's own PWRKEY still does the hardware 1 s
+// power-on / 4 s power-off; firmware never sees it.
+//
+// Hardware-confirmed on a unit, reading an EPUB end to end: panel bring-up through
+// the PMIC rail, NO_FLIP orientation, PCF85063 RTC, 4-bit SDMMC, buttons, and BOOT
+// waking the board out of deep sleep. The 20 MHz SPI clock stays: page-turn time is
+// panel waveform (407 ms) + gray display (226 ms) against 24 ms of SPI, so the
+// 40 MHz default would buy ~10 ms of 910. PENDING: the reused Sticky grayscale LUT.
+constexpr BoardProfile WS_EPAPER_397 = {
+    Board::WsEpaper397,
+    "ws397",
+    InputStyle::DigitalButtons,
+    DisplayController::SSD1677,
+    800,
+    480,
+    // SCK11 MOSI12 CS10 DC9 RST46 BUSY3; no power-enable GPIO (ALDO3, see above).
+    {11, 12, 10, 9, 46, 3, PIN_UNASSIGNED},
+    20000000,  // displaySpiHz: the vendor demo's 20 MHz; 0 would take the 40 MHz default
+    // SD is 4-bit SDMMC (sdmmc field below); these SPI pins are unused.
+    {PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, false, 0},
+    // back=BOOT(0), confirm=OK(5), no left/right, up=4, down=6. BOOT is also the
+    // power key (hold to sleep, press to wake) — it is the pin the vendor demo
+    // arms as its deep-sleep wake source. All active-low.
+    //
+    // GPIO38 is NOT a button: it is the AXP2101's active-low interrupt output,
+    // which sits LOW for as long as any PMIC interrupt is pending. Mapping it as
+    // a key reads as one held down forever. The case-labelled PWR key has not
+    // been located yet — see docs/waveshare-epaper-397-support.md.
+    {0, 5, PIN_UNASSIGNED, PIN_UNASSIGNED, 4, 6, 0, false},
+    PIN_UNASSIGNED,  // batteryAdc: none — the AXP2101 reports SoC over I2C
+    PIN_UNASSIGNED,  // batteryChargeStatus: PMIC register, not a pin
+    2.0f,
+    PIN_UNASSIGNED,  // usbDetect: PMIC VBUS status, not a pin
+    NO_TOUCH,
+    NO_FRONTLIGHT,
+    NO_AUDIO,  // ES8311 codec + NS4150B amp are wired but unused by the reader
+    NO_LEDS,
+    NO_FLIP,
+    {16, 17, 15, 7, 8, 18, 4},  // SDMMC 4-bit: CLK16 CMD17 D0=15 D1=7 D2=8 D3=18
+    // AXP2101 PMIC at 0x34 on the board's single I2C bus (SDA41/SCL42), read as a
+    // fuel gauge (percent + VBAT + charge state).
+    {41, 42, 400000, 0x34, 0, 0, GaugeType::Axp2101},
+    {MicInput::None, PIN_UNASSIGNED, PIN_UNASSIGNED, PIN_UNASSIGNED, true},
+    // Same I2C bus: PCF85063 RTC (0x51) and QMI8658 IMU (0x6B, probed 0x6A too).
+    // The SHTC3 (0x70) has no EnvironmentSensor backend yet, so it stays 0.
+    {41, 42, 400000, 0x51, 0, 0x6B, 0, RtcType::Pcf85063, ImuType::Qmi8658}};
+
 // --- Xteink X4 Pro — ESP32-S3, 800x480 EPD + GT911 touch + warm/cold frontlight ---
 // Recovered from the OEM flash dump (x4pro_flash_dump.bin); full evidence and confidence
 // levels in docs/xteink-x4pro-support.md. This is a DISTINCT device from the C3
@@ -1765,13 +1836,16 @@ constexpr uint32_t MAX_FRAMEBUFFER_BYTES = cmax(
                    FREEINK_DEVICE_PAPERMONO ? panelBytes(PAPER_MONO) : 0u),
               cmax(cmax(FREEINK_DEVICE_PAPERS3 ? panelBytes(M5PAPER_S3) : 0u,
                         FREEINK_DEVICE_MURPHY_M4 ? panelBytes(MURPHY_M4) : 0u),
-                   cmax(FREEINK_DEVICE_EEGO_A4 ? panelBytes(EEGO_A4) : 0u,
-                        FREEINK_DEVICE_ONEPAGE ? panelBytes(ONEPAGE) : 0u)))));
+                   cmax(cmax(FREEINK_DEVICE_EEGO_A4 ? panelBytes(EEGO_A4) : 0u,
+                             FREEINK_DEVICE_ONEPAGE ? panelBytes(ONEPAGE) : 0u),
+                        FREEINK_DEVICE_WS397 ? panelBytes(WS_EPAPER_397) : 0u)))));
 
 // Compile-time default device — the profile ACTIVE starts as. With a single
 // device in the build this is the only device; with several same-MCU devices it
 // is the boot default until the consumer calls selectDevice().
-#if FREEINK_DEVICE_ONEPAGE
+#if FREEINK_DEVICE_WS397
+constexpr BoardProfile DEFAULT_DEVICE = WS_EPAPER_397;
+#elif FREEINK_DEVICE_ONEPAGE
 constexpr BoardProfile DEFAULT_DEVICE = ONEPAGE;
 #elif FREEINK_DEVICE_PAPERMONO
 constexpr BoardProfile DEFAULT_DEVICE = PAPER_MONO;
@@ -1894,6 +1968,11 @@ inline bool selectDevice(Board which) {
       ACTIVE = ONEPAGE;
       break;
 #endif
+#if FREEINK_DEVICE_WS397
+    case Board::WsEpaper397:
+      ACTIVE = WS_EPAPER_397;
+      break;
+#endif
     default:
       return false;
   }
@@ -1916,6 +1995,7 @@ inline bool isX4Classic() { return ACTIVE.board == Board::XteinkX4Classic; }
 inline bool isPaperMono() { return ACTIVE.board == Board::PaperMono; }
 inline bool isEegoA4() { return ACTIVE.board == Board::EegoA4; }
 inline bool isOnePage() { return ACTIVE.board == Board::OnePage; }
+inline bool isWsEpaper397() { return ACTIVE.board == Board::WsEpaper397; }
 inline bool hasTouch() { return ACTIVE.touch.controller != TouchController::None; }
 inline bool hasHomeKey() { return ACTIVE.touch.hasHomeKey; }
 inline bool hasPwmFrontlight() { return ACTIVE.frontlight.gpio != PIN_UNASSIGNED || ACTIVE.frontlight.viaPm1Pwm; }

--- a/libs/hardware/PowerManager/src/PowerManager.cpp
+++ b/libs/hardware/PowerManager/src/PowerManager.cpp
@@ -5,6 +5,9 @@
 #include <driver/gpio.h>
 #include <esp_sleep.h>
 #include <soc/soc_caps.h>
+#if FREEINK_DEVICE_WS397
+#include <Axp2101.h>
+#endif
 
 namespace freeink {
 namespace {
@@ -73,6 +76,11 @@ void holdRailOff(int8_t pin, uint8_t offLevel) {
 
 void PowerManager::powerDownRailsForSleep() {
   const auto& b = BoardConfig::ACTIVE;
+#if FREEINK_DEVICE_WS397
+  // The EPD rail is an AXP2101 LDO, not a GPIO, so holdRailOff() below cannot
+  // reach it — drop it here or the panel stays powered all through deep sleep.
+  axp2101::setEpdPower(false);
+#endif
   // Keep RESET defined through deep sleep, but never drive an unpowered panel's
   // input HIGH: on boards with a gated EPD rail (Sticky), that can back-power the
   // controller through its RESET protection diode and turn sleep into a

--- a/libs/hardware/Rtc/src/Rtc.cpp
+++ b/libs/hardware/Rtc/src/Rtc.cpp
@@ -19,6 +19,13 @@ constexpr uint8_t PCF8563_REG_CLKOUT = 0x0D;
 constexpr uint8_t PCF8563_CLKOUT_DISABLED = 0x00;
 constexpr uint8_t PCF8563_VL_FLAG = 0x80;  // seconds reg bit7: oscillator stopped / voltage-low
 
+// PCF85063A register map. Same BCD time layout as the PCF8563 but shifted:
+// Control_1/2 at 0x00/0x01, time from 0x04, seconds bit7 is the OS (oscillator
+// stopped) flag, and Months carries no century bit.
+constexpr uint8_t PCF85063_REG_CONTROL1 = 0x00;
+constexpr uint8_t PCF85063_REG_TIME = 0x04;
+constexpr uint8_t PCF85063_OS_FLAG = 0x80;
+
 // DS3231 register map.
 constexpr uint8_t DS3231_REG_TIME = 0x00;  // seconds, minutes, hours, day, date, month, year
 constexpr uint8_t DS3231_REG_CONTROL = 0x0E;
@@ -93,6 +100,11 @@ bool Rtc::begin() {
       if (!readRegs(addr, PCF8563_REG_CONTROL_STATUS1, &status, 1)) return false;
       writeReg(addr, PCF8563_REG_CLKOUT, PCF8563_CLKOUT_DISABLED);  // we don't use the 32 kHz CLKOUT
       break;
+    case BoardConfig::RtcType::Pcf85063:
+      // No CLKOUT write: the PCF85063's CLKOUT lives in Control_2 alongside bits
+      // this driver has no business touching, and it boots disabled.
+      if (!readRegs(addr, PCF85063_REG_CONTROL1, &status, 1)) return false;
+      break;
     case BoardConfig::RtcType::Ds3231:
       if (!readRegs(addr, DS3231_REG_STATUS, &status, 1)) return false;
       writeReg(addr, DS3231_REG_CONTROL, DS3231_CONTROL_INTCN);  // disable square-wave output
@@ -124,6 +136,18 @@ bool Rtc::now(DateTime& out) {
       out.month = bcdToDec(raw[5] & 0x1FU);
       const uint8_t yy = bcdToDec(raw[6]);
       out.year = (raw[5] & 0x80U) ? static_cast<uint16_t>(1900 + yy) : static_cast<uint16_t>(2000 + yy);
+      return true;
+    }
+    case BoardConfig::RtcType::Pcf85063: {
+      if (!readRegs(addr, PCF85063_REG_TIME, raw, sizeof(raw))) return false;
+      if (raw[0] & PCF85063_OS_FLAG) return false;  // oscillator stopped -> time not trustworthy
+      out.second = bcdToDec(raw[0] & 0x7FU);
+      out.minute = bcdToDec(raw[1] & 0x7FU);
+      out.hour = bcdToDec(raw[2] & 0x3FU);
+      out.day = bcdToDec(raw[3] & 0x3FU);
+      out.weekday = bcdToDec(raw[4] & 0x07U);
+      out.month = bcdToDec(raw[5] & 0x1FU);
+      out.year = static_cast<uint16_t>(2000 + bcdToDec(raw[6]));
       return true;
     }
     case BoardConfig::RtcType::Ds3231: {
@@ -195,6 +219,18 @@ bool Rtc::set(const DateTime& dt) {
     const bool written = wire.endTransmission() == 0;
     const bool restarted = writeReg(addr, RX8130_REG_CONTROL0, static_cast<uint8_t>(control & ~RX8130_STOP));
     return written && restarted;
+  }
+  if (s.rtcType == BoardConfig::RtcType::Pcf85063) {
+    wire.beginTransmission(addr);
+    wire.write(PCF85063_REG_TIME);
+    wire.write(decToBcd(dt.second));  // also clears OS once a valid time is written
+    wire.write(decToBcd(dt.minute));
+    wire.write(decToBcd(dt.hour));
+    wire.write(decToBcd(dt.day));
+    wire.write(decToBcd(dt.weekday));
+    wire.write(decToBcd(dt.month));
+    wire.write(decToBcd(static_cast<uint8_t>(dt.year % 100)));
+    return wire.endTransmission() == 0;
   }
   wire.beginTransmission(addr);
   wire.write(s.rtcType == BoardConfig::RtcType::Pcf8563 ? PCF8563_REG_TIME : DS3231_REG_TIME);

--- a/platformio.sample.ini
+++ b/platformio.sample.ini
@@ -258,6 +258,25 @@ build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_STICKY=1
 
+; --- Waveshare ESP32-S3-ePaper-3.97 — ESP32-S3R8, SSD1677 800x480, AXP2101 -----
+; 3.97" 800x480 B/W e-paper (SSD1677, vendor sequences identical to the Sticky's).
+; Buttons-only: UP 4 / OK 5 / DOWN 6 plus BOOT (GPIO0), which doubles as Back and
+; as the only deep-sleep wake pin. SD is 4-bit SDMMC (FREEINK_SD_SDMMC auto-enables,
+; so the consumer build needs USE_BLOCK_DEVICE_INTERFACE=1). CAP_RTC (PCF85063) and
+; CAP_IMU (QMI8658) auto-enable on the SDA41/SCL42 bus.
+;
+; The AXP2101 PMIC (0x34, same bus) is load-bearing: ALDO3 is the e-paper rail, its
+; fuel-gauge block is the only battery telemetry, and PWRKEY is the hardware power
+; button. Axp2101.h owns it. See docs/waveshare-epaper-397-support.md.
+[env:ws397]
+extends = base
+board = esp32-s3-devkitc1-n16r8
+board_build.mcu = esp32s3
+build_flags =
+  ${base.build_flags}
+  -DUSE_BLOCK_DEVICE_INTERFACE=1
+  -DFREEINK_DEVICE_WS397=1
+
 ; --- Xteink X4 Pro — ESP32-S3 (8MB PSRAM), 800x480 EPD + GT911 + frontlight -----
 ; A distinct device from the C3 `x4` env above; production batches may carry
 ; SSD1677, UC8179, or UC8279 panel controllers. The board uses an ESP32-S3 with


### PR DESCRIPTION
Adds a board profile for the **Waveshare ESP32-S3-ePaper-3.97** — an ESP32-S3-WROOM-1-N16R8 carrier for a 3.97" 800x480 SSD1677 panel, with an AXP2101 PMIC, 4-bit SDMMC, PCF85063 RTC and a QMI8658 IMU.

Brought up on real hardware; `docs/waveshare-epaper-397-support.md` carries the per-pin evidence and the parts still unverified.

## What's here

- **Board profile + build composition** (`BoardConfig.h`): `FREEINK_DEVICE_WS397`, `Board::WsEpaper397`, `WS_EPAPER_397`. Pins come from the vendor demo sources ([waveshareteam/ESP32-S3-ePaper-3.97](https://github.com/waveshareteam/ESP32-S3-ePaper-3.97)), not from guesswork — each one is attributed to its source file in the doc.
- **`Axp2101.h`** (new): single owner of the PMIC bus. The PMIC is load-bearing here rather than an accessory — ALDO3 *is* the e-paper rail, so `EpdBus` powers it through the existing board hook and `PowerManager::powerDownRailsForSleep()` drops it before deep sleep (`holdRailOff()` cannot reach an LDO). Its fuel-gauge block is the board's only battery telemetry, hence `GaugeType::Axp2101` in `BatteryMonitor`.
- **Panel**: reuses `ssd1677StickyConfig()`. The vendor bring-up is byte-identical to Seeed's — same booster values, same `0x22` = F7 full / FF partial / D7 fast sequences — so this is one `case` rather than a new config.
- **`RtcType::Pcf85063`**: the PCF8563 register map shifted by two, with an OS flag instead of VL and no century bit.

## Verified on hardware

Panel bring-up through the PMIC rail (2.08 s full refresh), `NO_FLIP` orientation (text upright), PCF85063 RTC, 4-bit SDMMC carrying the section cache, buttons, deep sleep with BOOT wake, grayscale, and reading an EPUB end to end. ~240 KB of 329 KB heap free while reading.

## Still unverified

- The grayscale LUT is borrowed from the Sticky — same panel class, but it may want retuning if a unit shows banding on covers.
- The AXP2101 gauge learns its curve at runtime, so SoC is coarse until a full charge cycle.
- SPI stays at the vendor's 20 MHz. Raising it to the 40 MHz default is **not** worth it: a page turn measures 407 ms of BW waveform + 226 ms of gray display against 24 ms of actual SPI traffic.

## Note for reviewers

The board's case-labelled PWR key could not be located. A probe watching every unclaimed GPIO plus the PMIC interrupt registers caught nothing while it was pressed. GPIO38 is documented as a trap: it carries the AXP2101 active-low interrupt output, and mapping it as a key reads as one held down forever.

The companion firmware change is crosspoint-reader/crosspoint-reader (envs, board tag, keyboard fallback).