### PR TITLE
fix(sd): readFileToStream must feed the task watchdog

### DIFF
--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -2,6 +2,7 @@
 
 #include <BoardConfig.h>
 #include <driver/gpio.h>
+#include <esp_task_wdt.h>
 #include <SPI.h>
 #include <new>
 
@@ -273,12 +274,37 @@ bool SDCardManager::readFileToStream(const char* path, Print& out, const size_t 
   uint8_t buf[localBufSize];
   const size_t toRead = (chunkSize == 0) ? localBufSize : (chunkSize < localBufSize ? chunkSize : localBufSize);
 
+  // A big file streams for longer than the task watchdog allows, and nothing in
+  // this loop ever blocks long enough for the caller to feed it. Measured on a
+  // LilyGo T5 S3 Pro, 2026-09-06: a 733 kB file served over WebDAV reset the
+  // board 16 s into the transfer, 545 kB of it already delivered, with
+  // `task_wdt: - loopTask (CPU 1)` and this function in the backtrace.
+  //
+  // The yield belongs here rather than in the caller, which sees one call and
+  // has no place to put it. Budgeted by time, not per chunk: chunks are 256
+  // bytes, so that file is ~2900 iterations and a tick of delay on each would
+  // add ~2.9 s to every large read. Every 100 ms costs ~160 ms in total.
+  //
+  // `esp_task_wdt_reset()` is what actually feeds the watchdog -- `vTaskDelay`
+  // does not -- but it logs an error when the calling task is not subscribed,
+  // so ask once, quietly, instead of on every pass.
+  constexpr uint32_t yieldIntervalMs = 100;
+  const bool watchdogWatchesThisTask = (esp_task_wdt_status(nullptr) == ESP_OK);
+  uint32_t lastYieldMs = millis();
+
   while (f.available()) {
     const int r = f.read(buf, toRead);
-    if (r > 0) {
-      out.write(buf, static_cast<size_t>(r));
-    } else {
+    if (r <= 0) {
       break;
+    }
+    out.write(buf, static_cast<size_t>(r));
+
+    if (millis() - lastYieldMs >= yieldIntervalMs) {
+      if (watchdogWatchesThisTask) {
+        esp_task_wdt_reset();
+      }
+      vTaskDelay(1);  // let every other task on this core run
+      lastYieldMs = millis();
     }
   }
 


### PR DESCRIPTION
## The problem

`SDCardManager::readFileToStream()` streams a file in a loop that never blocks. The calling task therefore cannot feed the task watchdog while it runs, and on a large file the chip resets in the middle of the transfer.

Measured on a LilyGo T5 S3 Pro, 2026-09-06, serving a 733 kB file over WebDAV from the Arduino `WebServer` running in `loopTask`:

```
[179485] [DBG] [DAV] GET /trailink/base/13/4485/2842.tib
E (195459) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (195459) task_wdt:  - loopTask (CPU 1)
E (195459) task_wdt: Tasks currently running:
E (195459) task_wdt: CPU 0: wifi
E (195459) task_wdt: CPU 1: loopTask
E (195459) task_wdt: Aborting.
```

545 kB had already reached the client. The decoded backtrace puts this loop at the bottom of the stalled task:

```
CrossPointWebServer::handleClient
  WebServer::handleClient -> WebServer::_handleRequest -> RequestHandler::process
    <the caller's GET handler>
      SDCardManager::readFileToStream   SDCardManager.cpp:197
        NetworkClient::write
```

The caller cannot fix this. From its side it is one function call with no place to put a yield.

## The change

Yield on a time budget inside the loop, every 100 ms.

Time rather than per chunk: chunks are 256 bytes, so that file is about 2900 iterations, and one tick of delay on each would add roughly 2.9 s to every large read. At 100 ms the whole file costs about 160 ms of added delay.

`esp_task_wdt_reset()` is what actually feeds the watchdog, since `vTaskDelay()` does not. It logs an error when the calling task is not subscribed, so the subscription is checked once with `esp_task_wdt_status()` before the loop rather than on every pass. `vTaskDelay(1)` stays unconditional so other tasks run either way.

## Result, same board and same file

| | before | after |
|---|---|---|
| bytes delivered | 545 024 of 732 765 | 732 765 of 732 765 |
| outcome | task watchdog reset at 16 s | completed in 6.7 s |
| throughput | ~34 kB/s until the reset | ~109 kB/s |

Two consecutive downloads after the change are byte-for-byte identical, and the serial log carries no `task_wdt` line at all. Yielding did not cost throughput, it tripled it, because the transfer no longer holds the core against the networking stack.

Small files are unaffected: a 7.4 kB file returns its exact `Content-Length` as before.