### PR TITLE
Fix inverted text rendering black-on-black

### DIFF
--- a/libs/ui/FreeInkUI/src/FreeInkUI.cpp
+++ b/libs/ui/FreeInkUI/src/FreeInkUI.cpp
@@ -887,7 +887,12 @@ int16_t clampInt16(int32_t value, int16_t minValue, int16_t maxValue) {
 TextStyle textStyleWithForeground(TextStyle text, Paint foreground) {
   if (foreground.kind == PaintKind::Solid) {
     text.color = foreground.color;
-    text.inverted = foreground.color == Color::White;
+    // `color` already names the ink; DisplayTarget::text() treats `inverted`
+    // as a further flip of it. Setting both made a white foreground resolve
+    // back to black, so every inverted state (the default InvertFill list
+    // selection, an active button, a selected tab) drew black-on-black and
+    // lost its label. Carry the colour, and leave the flip to the caller.
+    text.inverted = false;
   }
   return text;
 }


### PR DESCRIPTION
`textStyleWithForeground()` sets both `text.color = White` and `text.inverted = true` when the resolved foreground is white. `DisplayTarget::text()` treats `inverted` as a *further* flip of `color`:

```cpp
const Color inkColor = style.inverted && style.color != Color::Transparent
                           ? invertedColor(style.color)
                           : style.color;
```

so the two cancel, `White` resolves back to `Black`, and glyphs are drawn in the same colour as the fill behind them. Each setting alone draws the text correctly; together they draw nothing visible.

This is the default path for `SelectionStyle::InvertFill`, which is the default `listSelectionStyle`, so a selected list row renders as a blank black bar. 29 call sites across 10 components resolve their text through this function (list, settingRow, button, checkbox, tabBar, dropdown, table, bookCard, coverGrid, metricCard), so any state resolving to a white foreground loses its label.

### It's a regression, and the committed gallery images show it

Re-rendering the gallery at current `main`:

```sh
sh libs/ui/FreeInkUI/tools/render_gallery.sh /tmp/g
```

| | images differing from the committed references |
|---|---|
| current `main` | **7** of 37 |
| with this change | **1** of 37 |

The six restored are `key-grid`, `list`, `radio-group`, `tab-bar`, `table` and `tile-grid` — precisely the components that draw an inverted state. The remaining difference, `qwerty-keyboard.svg`, is present both before and after and is unrelated to this change.

Single-file check:

```sh
cmp docs/images/freeinkui-components/list.svg /tmp/g/freeinkui-components/list.svg
```

The committed image shows "Reading" in white on the selected row; a fresh render at the same commit produces the same image with the label gone.

### The fix

Carry the colour and leave the flip to the caller — `color` already names the ink exactly, and a caller wanting a flip on top can still set `inverted` itself.

Happy to invert this (keep `inverted`, drop the colour assignment) if that better matches the intended semantics — I picked the direction that leaves `color` authoritative, but either resolves the double-application.

Found while building a host preview harness for the Paper Mono; the whole diff is one line plus a comment.