### PR TITLE
builder: add a Paper Mono device profile

### DIFF
--- a/libs/ui/FreeInkUI/tools/builder/builder.js
+++ b/libs/ui/FreeInkUI/tools/builder/builder.js
@@ -9,6 +9,7 @@ const devices = [
   { id: "sticky", label: "Sticky 800x480", width: 800, height: 480 },
   { id: "m5paper", label: "M5Paper 540x960", width: 540, height: 960 },
   { id: "lilygo", label: "LilyGo 960x540", width: 960, height: 540 },
+  { id: "papermono", label: "PaperMono 480x800", width: 480, height: 800 },
 ];
 
 const supported = new Set([


### PR DESCRIPTION
The M5Stack Paper Mono is already a first-class board — there's a `FREEINK_DEVICE_PAPERMONO` build flag, a full `BoardProfile PAPER_MONO` in `BoardConfig.h`, a `PaperMonoDriver` for its SSD1677, and a `papermono` env in `platformio.sample.ini` — but the bundled screen builder has no entry for it. Previewing a Paper Mono screen currently means picking another board's geometry and mentally correcting for it.

One line:

```js
{ id: "papermono", label: "PaperMono 480x800", width: 480, height: 800 },
```

Two notes on the details:

- **Added at the end of the list, not the start.** `devices[0]` is the builder's default, and this shouldn't change it for everyone else.
- **Declared 480x800**, the logical portrait frame the UI is authored against, rather than the panel-native 800x480 in `BoardProfile PAPER_MONO`. The builder derives its landscape view from the short and long sides, so the orientation control reads correctly either way — but the portrait figure is the one that matches what a screen function sees.

Verified by running the builder and rendering a 480x800 screen through `POST /api/render`.