### PR TITLE
fix(x3): skip POWER_ON on full sync when the UC8253 panel is already powered

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.cpp
@@ -194,8 +194,9 @@ bool Uc8253X3Driver::displayStart(EpdBus& bus, const uint8_t* fb, const uint8_t*
     bus.sendPlaneFlipped(CMD_DTM2, fb, _h, _wb);
   }
 
-  // doFullSync re-powers the charge pump even if already on (higher current).
-  if (!_isScreenOn || doFullSync) {
+  // PON only when the rails are down: a redundant PON on a powered UC8253 gives
+  // no BUSY LOW edge, so the X3TwoPhase wait burns its 1000 ms ceiling.
+  if (!_isScreenOn) {
     bus.cmd(CMD_POWER_ON);
     bus.waitBusy(" X3_PON");
     _isScreenOn = true;


### PR DESCRIPTION
## Summary

On the X3 (UC8253), every full-refresh page turn had ~1 s of dead time between the button press and the panel starting to flash. Differential turns were unaffected. One hunk in `Uc8253X3Driver::displayStart()`.

## Mechanism

`displayStart()` issued `CMD_POWER_ON` + `waitBusy(" X3_PON")` whenever `doFullSync` was true, even with `_isScreenOn == true` (`Uc8253X3Driver.cpp:197-202`). A redundant PON on an already-powered UC8253 produces no BUSY LOW edge, so `EpdBus::waitBusy(X3TwoPhase)` polls its full 1000 ms phase-1 ceiling and then returns without the `Wait complete` print (`EpdBus.cpp:280-302`). The stall sits between the frame write and `DISPLAY_REFRESH`, so nothing is visible on the panel while it runs.

Stock v1.6.0 log signature: ` X3_PON (128 ms)` printed once at boot (rails off), never before any full-refresh `X3_DRF`.

## Change

Gate PON on `!_isScreenOn`, as `triggerRefresh()` in the same file and `Uc8279Driver::displayStart()` already do. Boot, wake and `turnOff=true` refreshes still get a real PON.

The `|| doFullSync` condition came in with the initial import from the community SDK (e2ed8f7); the comment describing it as re-powering the charge pump "even if already on" was added the same day by the LUT-bank replacement (3a6e6bb), whose message does not mention power-on. The post-full condition pass and settle refresh already run without a re-power via `triggerRefresh()`.

## Measured (X3, UC8253, AA on, 2026-09-07)

| Full-refresh turn | before | after |
|---|---|---|
| PON wait | 1000 ms ceiling, silent | 0 ms (skipped) |
| plane writes -> `DISPLAY_REFRESH` | ~1050 ms | 54 ms |
| button press -> flash starts | ~1.2 s | 210 ms |

"Before" is the phase-1 ceiling plus the measured plane writes; "after" is from temporary timing prints not included in this PR. Fast turns unchanged (27 ms).

## Testing

Physical X3 (original batch, UC8253), CrossPoint `develop` b7bceb56 with this commit: ~60 pages with AA on and ~20 with AA off, five full refreshes under instrumentation, sleep/wake and cold boot. No new ghosting; full-refresh black level unchanged to the eye. UC8279 X3 path untouched.

### AI usage

Yes. Investigation, instrumentation, patch, and this description were done with an AI assistant; measurements and visual checks were on hardware.
