### PR TITLE
feat: expose grayscale base refresh support

### DIFF
--- a/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
+++ b/libs/display/FreeInkDisplay/include/FreeInkDisplay.h
@@ -94,8 +94,10 @@ class FreeInkDisplay {
 
   // Frame buffer operations
   void clearScreen(uint8_t color = 0xFF) const;
-  void drawImage(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool fromProgmem = false) const;
-  void drawImageTransparent(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool fromProgmem = false) const;
+  void drawImage(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                 bool fromProgmem = false) const;
+  void drawImageTransparent(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                            bool fromProgmem = false) const;
   // Persistent black/white output inversion. Framebuffers remain in their
   // normal logical colors, so callers keep drawing exactly as before; the
   // facade transforms frames only while sending them to the panel. The first
@@ -177,6 +179,9 @@ class FreeInkDisplay {
   // can skip overlap scaffolding (e.g. whole-plane grayscale buffers) when
   // there is nothing to overlap.
   bool supportsAsyncRefresh() const;
+  // True when the selected driver can use an ordinary deferred B/W refresh as
+  // the base for a following grayscale pass.
+  bool supportsAsyncGrayscaleBase() const;
 
   // ------------------------------------------------------------------------
   // CrossPoint EInkDisplay compatibility surface.

--- a/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
+++ b/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp
@@ -61,9 +61,12 @@ namespace freeink {
 namespace {
 RefreshMode toInternal(FreeInkDisplay::RefreshMode m) {
   switch (m) {
-    case FreeInkDisplay::FULL_REFRESH: return RefreshMode::Full;
-    case FreeInkDisplay::HALF_REFRESH: return RefreshMode::Half;
-    default: return RefreshMode::Fast;
+    case FreeInkDisplay::FULL_REFRESH:
+      return RefreshMode::Full;
+    case FreeInkDisplay::HALF_REFRESH:
+      return RefreshMode::Half;
+    default:
+      return RefreshMode::Fast;
   }
 }
 
@@ -76,7 +79,8 @@ void invertBytes(uint8_t* buffer, const uint32_t size) {
 }  // namespace
 
 FreeInkDisplay::FreeInkDisplay(int8_t sclk, int8_t mosi, int8_t cs, int8_t dc, int8_t rst, int8_t busy)
-    : _pins{sclk, mosi, cs, dc, rst, busy}, frameBuffer(nullptr)
+    : _pins{sclk, mosi, cs, dc, rst, busy},
+      frameBuffer(nullptr)
 #ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
       ,
       frameBufferActive(nullptr)
@@ -119,7 +123,7 @@ void FreeInkDisplay::selectDriver() {
 #if FREEINK_DRIVER_M5_OFFICIAL
       _driver = &m5OfficialDriver();  // M5 official M5GFX backend
 #else
-      _driver = &ed2208M5Driver();    // fast hand-rolled ED2208 backend
+      _driver = &ed2208M5Driver();  // fast hand-rolled ED2208 backend
 #endif
       break;
 #endif
@@ -432,10 +436,10 @@ uint8_t* FreeInkDisplay::lendBuildStorage(uint32_t* sizeOut) {
   }
   syncPendingAsync();  // a refresh in flight was reading these bytes
   _buildLent = true;
-  frameBuffer = nullptr;   // rendering is unavailable while the bytes are lent
-  _shadowValid = false;    // controller baseline no longer matches
+  frameBuffer = nullptr;                          // rendering is unavailable while the bytes are lent
+  _shadowValid = false;                           // controller baseline no longer matches
   if (sizeOut != nullptr) *sizeOut = bufferSize;  // full alloc is usable as scratch
-  return frameBuffer0;     // the allocation itself is never freed, so it never moves
+  return frameBuffer0;                            // the allocation itself is never freed, so it never moves
 }
 
 void FreeInkDisplay::returnBuildStorage() {
@@ -563,6 +567,10 @@ bool FreeInkDisplay::supportsAsyncRefresh() const {
   return !_inverted && !_inversionDirty && _driver != nullptr && _driver->supportsAsyncDisplay();
 }
 
+bool FreeInkDisplay::supportsAsyncGrayscaleBase() const {
+  return !_inverted && !_inversionDirty && _driver != nullptr && _driver->supportsAsyncGrayscaleBase();
+}
+
 bool FreeInkDisplay::refreshBusy() {
   // Does NOT clear the pending state on completion: the driver's post-waveform
   // work (X3 DTM1 sync) must run through displayFinish(). When this returns
@@ -686,8 +694,8 @@ void FreeInkDisplay::triggerDisplay(RefreshMode mode, bool turnOffScreen) {
   // into the inactive buffer while the just-displayed frame is preserved for the
   // X3 post-waveform DTM1 sync the driver stashed a pointer to.
   const RefreshMode effMode = resolveReleasedMode(mode);
-  const bool deferred = _driver->displayStart(_bus, frameBuffer, consumePrevFrameFor(effMode), toInternal(effMode),
-                                              turnOffScreen);
+  const bool deferred =
+      _driver->displayStart(_bus, frameBuffer, consumePrevFrameFor(effMode), toInternal(effMode), turnOffScreen);
   swapBuffers();
 #endif
   _refreshPending = deferred;
@@ -839,8 +847,7 @@ void FreeInkDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) {
   _driver->copyGrayscaleMsb(_bus, msbBuffer);
 }
 
-void FreeInkDisplay::writeGrayscalePlaneStrip(GrayPlane plane, const uint8_t* rows, uint16_t yStart,
-                                              uint16_t numRows) {
+void FreeInkDisplay::writeGrayscalePlaneStrip(GrayPlane plane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
   if (_inverted) return;
   // Paper Mono retains these bytes in PSRAM and performs no bus access here, so
   // staging can overlap the B/W waveform. Other drivers may write controller
@@ -873,8 +880,7 @@ void FreeInkDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) {
   }
   // Restore frameBuffer so subsequent BW draws paint onto a valid BW baseline
   // rather than the stale LSB/MSB grayscale plane data that was there before.
-  if (frameBuffer && bwBuffer && frameBuffer != bwBuffer)
-    memcpy(frameBuffer, bwBuffer, bufferSize);
+  if (frameBuffer && bwBuffer && frameBuffer != bwBuffer) memcpy(frameBuffer, bwBuffer, bufferSize);
 }
 #ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
 void FreeInkDisplay::cleanupGrayscaleWithPreviousBuffer() {
@@ -882,8 +888,7 @@ void FreeInkDisplay::cleanupGrayscaleWithPreviousBuffer() {
   if (!_inverted) {
     _driver->cleanupGrayscaleBuffers(_bus, baseline);
   }
-  if (frameBuffer && baseline && frameBuffer != baseline)
-    memcpy(frameBuffer, baseline, bufferSize);
+  if (frameBuffer && baseline && frameBuffer != baseline) memcpy(frameBuffer, baseline, bufferSize);
 }
 #endif
 
@@ -903,13 +908,9 @@ void FreeInkDisplay::abortPostRefresh() {
   if (_driver) _driver->abortPostRefresh();
 }
 
-bool FreeInkDisplay::postRefreshAborted() const {
-  return _driver && _driver->postRefreshAborted();
-}
+bool FreeInkDisplay::postRefreshAborted() const { return _driver && _driver->postRefreshAborted(); }
 
-bool FreeInkDisplay::displayCommitted() const {
-  return !_driver || _driver->displayCommitted();
-}
+bool FreeInkDisplay::displayCommitted() const { return !_driver || _driver->displayCommitted(); }
 
 void FreeInkDisplay::runMaintenance() {
   if (!_driver) return;
@@ -917,9 +918,7 @@ void FreeInkDisplay::runMaintenance() {
   _driver->runMaintenance(_bus);
 }
 
-bool FreeInkDisplay::hasPendingMaintenance() const {
-  return _driver && _driver->hasPendingMaintenance();
-}
+bool FreeInkDisplay::hasPendingMaintenance() const { return _driver && _driver->hasPendingMaintenance(); }
 
 void FreeInkDisplay::controllerIdle() {
   if (!_driver) return;
@@ -943,9 +942,7 @@ void FreeInkDisplay::setFastRefreshCutoffMs(uint16_t ms) {
   if (_driver) _driver->setFastRefreshCutoffMs(ms);
 }
 
-uint16_t FreeInkDisplay::fastRefreshCutoffMs() const {
-  return _driver ? _driver->fastRefreshCutoffMs() : 0;
-}
+uint16_t FreeInkDisplay::fastRefreshCutoffMs() const { return _driver ? _driver->fastRefreshCutoffMs() : 0; }
 
 void FreeInkDisplay::setHoldPeriodicFullRefresh(bool hold) {
   if (_driver) _driver->setHoldPeriodicFull(hold);

--- a/libs/display/FreeInkDisplay/src/driver/PanelDriver.h
+++ b/libs/display/FreeInkDisplay/src/driver/PanelDriver.h
@@ -37,7 +37,7 @@ class PanelDriver {
   virtual BusyPolarity busyPolarity() const = 0;
   virtual PanelGeometry geometry() const = 0;
   virtual int8_t spiMiso() const { return -1; }  // SSD1677 uses none; M5 shares MISO
-  virtual int8_t coCs() const { return -1; }      // co-resident SPI CS to hold high (M5 SD)
+  virtual int8_t coCs() const { return -1; }     // co-resident SPI CS to hold high (M5 SD)
 
   // True for drivers backed by an external library that manages its own SPI /
   // display hardware (e.g. M5GFX, EPD_Painter). When true the facade does NOT
@@ -86,7 +86,10 @@ class PanelDriver {
   // `fb` is the just-displayed frame, re-supplied fresh by the facade at finish
   // time (not stashed at start): callers may release/realloc the buffer holding
   // it between the two calls, so the driver must not cache the pointer.
-  virtual void displayFinish(EpdBus& bus, const uint8_t* fb) { (void)bus; (void)fb; }
+  virtual void displayFinish(EpdBus& bus, const uint8_t* fb) {
+    (void)bus;
+    (void)fb;
+  }
 
   // Re-seed the controller's host-managed previous-frame plane (SSD1677 RED RAM)
   // with `buf`, WITHOUT triggering a refresh. A dual-buffer fast refresh only
@@ -97,10 +100,17 @@ class PanelDriver {
   // RED holds. Callers seed the on-screen frame here just before releasing so that
   // first differential diff has a correct baseline. Default no-op: controllers with
   // no host-managed previous-frame plane (X3 DTM1, M5) keep their own baseline.
-  virtual void seedPreviousFrame(EpdBus& bus, const uint8_t* buf) { (void)bus; (void)buf; }
+  virtual void seedPreviousFrame(EpdBus& bus, const uint8_t* buf) {
+    (void)bus;
+    (void)buf;
+  }
 
   // --- grayscale (dual-plane LSB/MSB) ---
   virtual bool supportsStripGrayscale() const { return false; }
+  // True when an ordinary deferred B/W refresh is a valid base for a
+  // grayscale pass. Drivers with a dedicated grayscale-base waveform must
+  // override this even when their normal display path supports deferral.
+  virtual bool supportsAsyncGrayscaleBase() const { return false; }
   // True when displayGrayscaleBase() DEFERS the base activation so the gray
   // planes join it in a single waveform (Paper Mono). Hosts should then route the
   // grayscale base through displayGrayscaleBase() instead of display(): a
@@ -121,17 +131,31 @@ class PanelDriver {
   // the BW base frame is displayed, before grayscale planes are written.
   // Default no-op for panels whose grayscale needs no conditioning.
   virtual void preconditionGrayscale(EpdBus& bus, uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
-    (void)bus; (void)x; (void)y; (void)w; (void)h;
+    (void)bus;
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)h;
   }
-  virtual void copyGrayscaleLsb(EpdBus& bus, const uint8_t* lsb) { (void)bus; (void)lsb; }
-  virtual void copyGrayscaleMsb(EpdBus& bus, const uint8_t* msb) { (void)bus; (void)msb; }
+  virtual void copyGrayscaleLsb(EpdBus& bus, const uint8_t* lsb) {
+    (void)bus;
+    (void)lsb;
+  }
+  virtual void copyGrayscaleMsb(EpdBus& bus, const uint8_t* msb) {
+    (void)bus;
+    (void)msb;
+  }
   // Host-retained selector planes can be copied and encoded while the previous
   // B/W waveform is BUSY. Drivers returning true must not touch SPI in either
   // writeGrayscalePlaneStrip() or prepareGrayscaleTarget().
   virtual bool supportsBusyGrayscaleStaging() const { return false; }
   virtual void writeGrayscalePlaneStrip(EpdBus& bus, GrayPlane plane, const uint8_t* rows, uint16_t yStart,
                                         uint16_t numRows) {
-    (void)bus; (void)plane; (void)rows; (void)yStart; (void)numRows;
+    (void)bus;
+    (void)plane;
+    (void)rows;
+    (void)yStart;
+    (void)numRows;
   }
   virtual void prepareGrayscaleTarget(const uint8_t* bw) { (void)bw; }
   virtual void displayGray(EpdBus& bus, const uint8_t* fb, bool turnOff, const unsigned char* lut, bool factoryMode) {
@@ -150,7 +174,10 @@ class PanelDriver {
     (void)customH;
     displayGray(bus, fb, false, nullptr, true);
   }
-  virtual void cleanupGrayscaleBuffers(EpdBus& bus, const uint8_t* bw) { (void)bus; (void)bw; }
+  virtual void cleanupGrayscaleBuffers(EpdBus& bus, const uint8_t* bw) {
+    (void)bus;
+    (void)bw;
+  }
 
   // --- optional, controller-specific hooks (no-op by default) ---
   virtual void requestResync(uint8_t settlePasses) { (void)settlePasses; }
@@ -220,8 +247,15 @@ class PanelDriver {
   // full, so the drag stays flash-free. Clear it and force one full afterward to
   // scrub any accumulated ghost. No-op on drivers without a periodic-full cadence.
   virtual void setHoldPeriodicFull(bool hold) { (void)hold; }
-  virtual void grayscaleRevert(EpdBus& bus, const uint8_t* fb) { (void)bus; (void)fb; }
-  virtual void setCustomLut(EpdBus& bus, bool enabled, const unsigned char* data) { (void)bus; (void)enabled; (void)data; }
+  virtual void grayscaleRevert(EpdBus& bus, const uint8_t* fb) {
+    (void)bus;
+    (void)fb;
+  }
+  virtual void setCustomLut(EpdBus& bus, bool enabled, const unsigned char* data) {
+    (void)bus;
+    (void)enabled;
+    (void)data;
+  }
 };
 
 }  // namespace freeink

--- a/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.h
+++ b/libs/display/FreeInkDisplay/src/driver/Ssd1677Driver.h
@@ -17,10 +17,10 @@ namespace freeink {
 
 // Device-tunable SSD1677 waveform/config. A board overrides only what differs.
 struct Ssd1677Config {
-  uint8_t booster[5];               // booster soft-start (CMD 0x0C)
-  uint8_t driverOutputScan;         // CMD 0x01 base scan byte (0x02); mirrorY ORs TB
-  uint8_t borderWaveformInit;        // CMD 0x3C value written during controller init
-  uint8_t halfRefreshTemp;          // temperature byte written for HALF refresh
+  uint8_t booster[5];            // booster soft-start (CMD 0x0C)
+  uint8_t driverOutputScan;      // CMD 0x01 base scan byte (0x02); mirrorY ORs TB
+  uint8_t borderWaveformInit;    // CMD 0x3C value written during controller init
+  uint8_t halfRefreshTemp;       // temperature byte written for HALF refresh
   const unsigned char* grayLut;  // 110-byte custom LUT for grayscale display
   // Absolute Display Update Control 2 (0x22) sequence values, per refresh type.
   // 0 = use the driver's built-in X4 values (incremental, keeps the panel powered
@@ -85,6 +85,7 @@ class Ssd1677Driver : public PanelDriver {
   void seedPreviousFrame(EpdBus& bus, const uint8_t* buf) override;
 
   bool supportsStripGrayscale() const override { return true; }
+  bool supportsAsyncGrayscaleBase() const override { return true; }
   void copyGrayscaleLsb(EpdBus& bus, const uint8_t* lsb) override;
   void copyGrayscaleMsb(EpdBus& bus, const uint8_t* msb) override;
   void writeGrayscalePlaneStrip(EpdBus& bus, GrayPlane plane, const uint8_t* rows, uint16_t yStart,

--- a/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.h
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8253X3Driver.h
@@ -30,10 +30,10 @@ struct Uc8253LutBank {
 };
 
 struct Uc8253X3Config {
-  Uc8253LutBank normal;  // condition-pass / settle (CDI 0xA9)
-  Uc8253LutBank half;    // scrub (CDI 0xA9)
-  Uc8253LutBank fast;    // turbo differential (CDI 0x29)
-  Uc8253LutBank full;    // OEM full / factory (CDI 0x29)
+  Uc8253LutBank normal;    // condition-pass / settle (CDI 0xA9)
+  Uc8253LutBank half;      // scrub (CDI 0xA9)
+  Uc8253LutBank fast;      // turbo differential (CDI 0x29)
+  Uc8253LutBank full;      // OEM full / factory (CDI 0x29)
   Uc8253LutBank gc;        // OEM 4-level grayscale nudge (CDI 0x29)
   Uc8253LutBank preBwMid;  // OEM grayscale preconditioning settle (CDI 0xA9)
   uint8_t lutLen;          // bytes per LUT sent to the controller (42)
@@ -62,6 +62,7 @@ class Uc8253X3Driver : public PanelDriver {
   bool supportsAsyncDisplay() const override { return true; }
 
   bool supportsStripGrayscale() const override { return true; }
+  bool supportsAsyncGrayscaleBase() const override { return false; }
   void displayGrayscaleBase(EpdBus& bus, const uint8_t* fb, RefreshMode fallback, bool turnOff) override;
   void preconditionGrayscale(EpdBus& bus, uint16_t x, uint16_t y, uint16_t w, uint16_t h) override;
   void copyGrayscaleLsb(EpdBus& bus, const uint8_t* lsb) override;

--- a/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.h
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.h
@@ -52,6 +52,7 @@ class Uc8279Driver : public PanelDriver {
   // external XTF_AA LUT bank resolves them. displayGrayscaleBase / precondition
   // run the OEM XTF_PRE_BW_MID "AA-pre-BW(mid)" settle before the gray planes.
   bool supportsStripGrayscale() const override { return true; }
+  bool supportsAsyncGrayscaleBase() const override { return false; }
   void displayGrayscaleBase(EpdBus& bus, const uint8_t* fb, RefreshMode fallback, bool turnOff) override;
   void preconditionGrayscale(EpdBus& bus, uint16_t x, uint16_t y, uint16_t w, uint16_t h) override;
   void copyGrayscaleLsb(EpdBus& bus, const uint8_t* lsb) override;
@@ -86,8 +87,8 @@ class Uc8279Driver : public PanelDriver {
   uint32_t _bufferSize;
 
   bool _isScreenOn = false;
-  bool _firstRefresh = true;   // CDI 0x97 on the first refresh after init, 0xD7 after
-  bool _oldPlaneValid = false; // DTM1 holds a real previous frame (differential baseline)
+  bool _firstRefresh = true;    // CDI 0x97 on the first refresh after init, 0xD7 after
+  bool _oldPlaneValid = false;  // DTM1 holds a real previous frame (differential baseline)
   bool _forceFullSyncNext = false;
   // Boot initial-full budget: force GC (strong clear) for this many content
   // paints after begin(), so the first screen after the splash is a real clear


### PR DESCRIPTION
## Summary

- Adds `supportsAsyncGrayscaleBase()` as a way for each display driver to indicate whether it supports using a normal async refresh before grayscale is applied.
- Enables this by default for SSD1677 displays.
- Keeps it disabled for X3's UC8253 and UC8279d display types, since they need their own grayscale refresh sequence.

## Additional Context

This moves the display-specific decision into the SDK instead of having CrossPoint check whether the device is an X3.

Both current X3 displays need the special grayscale path, but keeping that detail with each display driver makes it easier to support future display variants correctly.

This does not change display behavior on its own. It only gives apps a safer way to choose the correct refresh path.

Relates to Crosspoint PR #3439 (which will be dependent on this) and issue #3400