### PR TITLE
fix(uc8279): exchange WW/WB registers when loading the X3 AA tables

### DIFF
--- a/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
+++ b/libs/display/FreeInkDisplay/src/driver/Uc8279Driver.cpp
@@ -17,7 +17,11 @@ constexpr uint8_t CMD_DTM1 = 0x10;                // OLD plane in KW mode
 constexpr uint8_t CMD_DATA_STOP = 0x11;           // DSP
 constexpr uint8_t CMD_DISPLAY_REFRESH = 0x12;     // DRF
 constexpr uint8_t CMD_DTM2 = 0x13;                // NEW plane in KW mode
-constexpr uint8_t CMD_LUT_VCOM = 0x20;             // first LUT register (0x20-0x24)
+constexpr uint8_t CMD_LUT_VCOM = 0x20;            // LUT registers 0x20-0x24
+constexpr uint8_t CMD_LUT_WW = 0x21;
+constexpr uint8_t CMD_LUT_BW = 0x22;
+constexpr uint8_t CMD_LUT_WB = 0x23;
+constexpr uint8_t CMD_LUT_BB = 0x24;
 constexpr uint8_t CMD_VCOM_DATA_INTERVAL = 0x50;  // CDI
 constexpr uint8_t CMD_PARTIAL_WINDOW = 0x90;      // PTL
 constexpr uint8_t CMD_PARTIAL_IN = 0x91;          // PTIN
@@ -59,10 +63,16 @@ void Uc8279Driver::loadBank(EpdBus& bus, const uint8_t (*bank)[43]) {
 }
 
 void Uc8279Driver::loadXtfAa(EpdBus& bus) {
-  // Raw (non-prefixed) 49-byte AA tables: send the register 0x20+t, then the
-  // whole table (FUN_42013be0).
+  // Raw (non-prefixed) 49-byte AA tables: send the register, then the whole
+  // table (FUN_42013be0). The stock set encodes dark gray as old=1/new=0 (WB)
+  // and leaves WW passive. CrossPoint's planes encode dark gray as
+  // old=1/new=1 (WW), so the WW and WB tables are exchanged on upload;
+  // without this, level 1 selects the passive table and renders black. The
+  // table bytes stay stock, as with the X4 XTH4 register exchange.
+  // Stock table order is VCOM, WW, BW, WB, BB.
+  static constexpr uint8_t kReg[5] = {CMD_LUT_VCOM, CMD_LUT_WB, CMD_LUT_BW, CMD_LUT_WW, CMD_LUT_BB};
   for (int t = 0; t < 5; t++) {
-    bus.cmd(static_cast<uint8_t>(CMD_LUT_VCOM + t));
+    bus.cmd(kReg[t]);
     bus.data(kUc8279X3_XtfAa[t], 49);
   }
 }


### PR DESCRIPTION
## Summary

On the UC8279 Xteink X3, level-1 (dark gray) pixels in the 4-level grayscale path rendered black. `loadXtfAa()` uploaded the stock AA tables in row order, so the WW register (0x21) held the passive table while the 2-frame dark-gray drive sat in WB (0x23). CrossPoint's plane encoding (LSB to DTM1, MSB to DTM2, set bit = white) puts dark gray at old=1/new=1, which selects WW, so the pixel never moved. The stock firmware encodes dark gray as old=1/new=0 and reaches WB; the UC8253 X3 bank was written for CrossPoint's encoding and drives WW, so the two X3 variants disagreed.

This exchanges the WW and WB registers on upload and leaves the table bytes stock, the same approach as the X4 XTH4 path in e85297e.

Fixes #93.

## Validation

Xteink X3 (UC8279, panel ZHX368), CrossPoint BMP viewer grayscale path, 528x792 4-bit native-palette test image with flat patches at all four levels, photographed in raw and measured as position between the black and white patches. Two shots per state.

| | before | after |
| --- | --- | --- |
| dark gray | 0.00, 0.00 | 0.24, 0.21 |
| light gray | 0.77, 0.79 | 0.79, 0.77 |

Black, white and light gray are unchanged; a dithered dark-gray-on-black patch goes from solid black to a visible gray speckle. The register contents uploaded by this change are byte-identical to the table-row swap that was flashed for those measurements.

## Notes

The glyph anti-aliasing path uses the same table, so AA edge pixels at level 1 now render dark gray on this driver instead of black, matching the UC8253 X3 behaviour.
