### PR TITLE
fix(content): take the inflate window before the cipher scratch

### DIFF
--- a/libs/book/ContentProtection/src/ProtectedBook.cpp
+++ b/libs/book/ContentProtection/src/ProtectedBook.cpp
@@ -227,22 +227,29 @@ bool ProtectedBook::decryptEntryToSink(ByteSource& source, Crypto& crypto,
 
   constexpr size_t kCipherChunk = 2048;
   constexpr size_t kOutputChunk = 4096;
+
+  // Biggest allocation first. mz_inflateInit2 needs ~40KB in ONE block (an
+  // inflate_state: the tinfl decompressor plus a 32KB dictionary), while the
+  // scratch below is 8KB. Taking the 8KB first can carve it out of the very
+  // block the 40KB needs, so a heap whose largest free region is ~47KB -- ample
+  // for the window on its own -- fails on the pair. Measured on device: image
+  // extraction refused at maxAlloc=47092 with 41168 required.
+  mz_stream stream;
+  memset(&stream, 0, sizeof(stream));
+  if (mz_inflateInit2(&stream, -15) != MZ_OK) {
+    lastError_ = "inflate setup failed";
+    return false;
+  }
+
   auto* buffers = static_cast<uint8_t*>(malloc(kCipherChunk * 2 + kOutputChunk));
   if (!buffers) {
+    mz_inflateEnd(&stream);
     lastError_ = "insufficient memory for content stream";
     return false;
   }
   uint8_t* cipher = buffers;
   uint8_t* plain = cipher + kCipherChunk;
   uint8_t* output = plain + kCipherChunk;
-
-  mz_stream stream;
-  memset(&stream, 0, sizeof(stream));
-  if (mz_inflateInit2(&stream, -15) != MZ_OK) {
-    free(buffers);
-    lastError_ = "inflate setup failed";
-    return false;
-  }
 
   bool ended = false;
   auto inflateChunk = [&](const uint8_t* data, size_t size) {


### PR DESCRIPTION
`decryptEntryToSink` allocates its 8KB cipher/plain/output scratch before asking miniz for the inflate state. That state is a single 41168-byte block — a `tinfl_decompressor` plus the 32KB dictionary — so when both come from the same free region the pair needs ~49KB contiguous, even though the window alone needs 40KB.

On an ESP32-C3 whose largest free block was 47092 bytes, the 8KB was carved out of that block and `mz_inflateInit2` then failed. Decryption was refused for an image that had ample room for the window itself.

Allocating the larger block first fixes it: the 8KB scratch is small enough to be served from anywhere.

## Testing

Found while debugging an ADEPT-protected EPUB on an X4 (ESP32-C3, 380KB RAM): a JPEG on a chapter page failed to extract at `maxAlloc=47092`, and rendered a placeholder instead. With this change the same page extracts, decodes and caches normally.

`libs/book/ContentProtection/test/host/run.sh` passes. Also exercised `ProtectedBook::open()` on the real protected EPUB before and after — identical results (manifest scanned, 97 encrypted entries found, expected failure at key unwrap with no credential).

Behaviour is otherwise unchanged. `mz_inflateEnd` now runs on the scratch-allocation failure path, which previously could not be reached.

`scanEncryptionXml` has the same allocate-small-first shape, but it runs at book open when the heap is healthy and it fails loudly rather than silently, so I left it alone.
